### PR TITLE
ec2_instance_terminate_by_tag: Remove verbosity conflicting with debug, fix conditional statement

### DIFF
--- a/roles/ec2_instance_terminate_by_tag/tasks/main.yml
+++ b/roles/ec2_instance_terminate_by_tag/tasks/main.yml
@@ -45,6 +45,8 @@
       with_items:
         - "{{ instance_ids }}"
 
+  always:
+
     - name: Create list of terminated instances
       ansible.builtin.set_fact:
         terminated_instances: "{{ terminate_result.results | map(attribute='terminate_success') | list | flatten }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR makes following minor fixes to `ec2_instance_terminate_by_tag` role.

1. Remove `verbosity` param as it conflicts with `debug` param throwing following error
```
ERROR! conflicting action statements: debug, verbosity
```

2. Remove `jinja` from `when` conditional statement to resolve warning
```
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. 
Found: {{ terminated_instances | length }} != 0
```

3. Added `always` block to handle following
currently if the `protected` instances throw [error while termination in task here](https://github.com/ansible-collections/cloud.aws_roles/blob/main/roles/ec2_instance_terminate_by_tag/tasks/main.yml#L40-L47), the playbook code does not reach to tasks for [creating and printing list of instances ](https://github.com/ansible-collections/cloud.aws_roles/blob/main/roles/ec2_instance_terminate_by_tag/tasks/main.yml#L49-L55)that are terminated successfully.
Adding `always` will help playbook reach the create/print list tasks even if error in termination task.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance_terminate_by_tag