### PR TITLE
ec2_instance_terminate_by_tag: add dependency with aws_setup_credentials role

### DIFF
--- a/roles/ec2_instance_terminate_by_tag/README.md
+++ b/roles/ec2_instance_terminate_by_tag/README.md
@@ -20,6 +20,11 @@ This role will terminate the instances with the specified tag even if they are a
 The attached EBS volumes to the instances are deleted when instance is terminated if `Delete on Termination` is set to `True`.
 If `Delete on Termination` is set to `False`, the volume will be detached from the instance and will not be deleted.
 
+Dependencies
+------------
+
+- role: [aws_setup_credentials](../aws_setup_credentials/README.md)
+
 ## Example:
 ```
 ---

--- a/roles/ec2_instance_terminate_by_tag/meta/main.yml
+++ b/roles/ec2_instance_terminate_by_tag/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - aws_setup_credentials

--- a/roles/ec2_instance_terminate_by_tag/tasks/main.yml
+++ b/roles/ec2_instance_terminate_by_tag/tasks/main.yml
@@ -54,3 +54,7 @@
         msg:
           - "Terminated instances successfully -> {{ terminated_instances }}"
       when: terminated_instances | length != 0
+
+  module_defaults:
+    group/aws:
+      "{{ aws_role_credentials }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added dependency with `aws_setup_credentials` role in `ec2_instance_terminate_by_tag`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance_terminate_by_tag