### PR TITLE
Fix test_customized_ami - missing RSA keys to run integration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,6 +42,10 @@ jobs:
           collection_path: ${{ steps.install-collection.outputs.collection_path }}
           ansible_core_ci_key: ${{ secrets.ANSIBLE_CORE_CI_KEY }}
 
+      - name: Generate RSA keys (need to run integration test target test_customized_ami)
+        run: ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa <<<y >/dev/null 2>&1
+        shell: bash
+
       # we use raw git to create a repository in the tests
       # this fails if the committer doesn't have a name and an email set
       - name: Set up git


### PR DESCRIPTION
Integration tests `test_customized_ami` is failing due to missing RSA Keys
This fix basically creates the RSA keys prior to running the tests.