### PR TITLE
Fix test_customized_ami - add missing RSA public and private ssh keys

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ jobs:
     env:
       source: "./source"
       aws_dir: "./amazon_aws"
+      crypto_dir: "./community.crypto"
       ansible_version: "stable-2.14"
       python_version: "3.9"
     steps:
@@ -23,6 +24,7 @@ jobs:
           install_python_dependencies: false
           source_path: ${{ env.source }}
 
+      # checkout and install 'amazon.aws'
       - name: checkout ansible-collections/amazon.aws
         uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
         with:
@@ -35,6 +37,20 @@ jobs:
         with:
           install_python_dependencies: true
           source_path: ${{ env.amazon_aws }}
+
+      # checkout and install 'community.crypto'
+      - name: checkout ansible-collections/community.crypto
+        uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
+        with:
+          repository: ansible-collections/community.crypto
+          path: ${{ env.crypto_dir }}
+          ref: main
+
+      - name: install community.crypto collection
+        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
+        with:
+          install_python_dependencies: false
+          source_path: ${{ env.crypto_dir }}
 
       - name: Create AWS/sts session credentials
         uses: ansible-network/github_actions/.github/actions/ansible_aws_test_provider@main
@@ -56,4 +72,4 @@ jobs:
           collection_path: ${{ steps.install-collection.outputs.collection_path }}
           python_version: ${{ env.python_version }}
           ansible_version: ${{ env.ansible_version }}
-          ansible_test_requirement_files: ''
+          ansible_test_requirement_files: 'test-requirements.txt'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /tests/output/
 /tests/integration/inventory
 /changelogs/.plugin-cache.yaml
+tests/integration/cloud-config-*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+cryptography

--- a/tests/integration/targets/setup_rsa_keys/handlers/main.yml
+++ b/tests/integration/targets/setup_rsa_keys/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Delete temporary RSA key directory
+  ansible.builtin.file:
+    state: absent
+    path: "{{ setup_rsa_keys__tmpdir }}"
+  ignore_errors: true

--- a/tests/integration/targets/setup_rsa_keys/tasks/main.yml
+++ b/tests/integration/targets/setup_rsa_keys/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Create temporary directory to generate keys
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: ssh
+  register: setup_rsa_keys__tmpdir
+  notify: 'Delete temporary RSA key directory'
+
+- name: Generate RSA keys
+  community.crypto.openssh_keypair:
+    path: "{{ setup_rsa_keys__tmpdir.path }}/id_rsa"
+
+- name: Define path to private and public keys
+  ansible.builtin.set_fact:
+    setup_rsa_keys__public_key_file: "{{ setup_rsa_keys__tmpdir.path }}/id_rsa.pub"
+    setup_rsa_keys__private_key_file: "{{ setup_rsa_keys__tmpdir.path }}/id_rsa"

--- a/tests/integration/targets/test_customized_ami/defaults/main.yml
+++ b/tests/integration/targets/test_customized_ami/defaults/main.yml
@@ -7,7 +7,5 @@ ami_vpc_name: "vpc-{{ resource_prefix }}"
 ami_security_group: "security-group-{{ resource_prefix }}"
 ami_security_group_desc: "Allow connection to instance via SSH port"
 ami_key_name: "key-{{ resource_prefix }}"
-ami_public_key_file: ~/.ssh/id_rsa.pub
-ami_private_key_file: ~/.ssh/id_rsa.pub
 ami_user_name: fedora
 ami_ec2_instance_type: t2.micro

--- a/tests/integration/targets/test_customized_ami/meta/main.yml
+++ b/tests/integration/targets/test_customized_ami/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: setup_rsa_keys

--- a/tests/integration/targets/test_customized_ami/tasks/create_infra.yml
+++ b/tests/integration/targets/test_customized_ami/tasks/create_infra.yml
@@ -57,7 +57,7 @@
     - name: Create key pair to connect to the VM
       amazon.aws.ec2_key:
         name: "{{ ami_key_name }}"
-        key_material: "{{ lookup('file', ami_public_key_file) }}"
+        key_material: "{{ lookup('file', setup_rsa_keys__public_key_file) }}"
 
     - name: Get custom AMI information
       amazon.aws.ec2_ami_info:
@@ -92,5 +92,5 @@
         hostname: "{{ ami_ec2_instance_name }}"
         ansible_ssh_user: "{{ ami_user_name }}"
         ansible_host: "{{ test__ec2_instance.instances.0.public_ip_address }}"
-        ansible_ssh_common_args: -o "UserKnownHostsFile=/dev/null" -o StrictHostKeyChecking=no -i {{ ami_private_key_file }}
+        ansible_ssh_common_args: -o "UserKnownHostsFile=/dev/null" -o StrictHostKeyChecking=no -i {{ setup_rsa_keys__private_key_file }}
         ansible_python_interpreter: auto

--- a/tests/integration/targets/test_customized_ami/tasks/main.yml
+++ b/tests/integration/targets/test_customized_ami/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Test role 'customized_ami'
   vars:
     custom_ami_ec2_instance_type: t2.micro
+    custom_ami_public_key_file: "{{ setup_rsa_keys__public_key_file }}"
+    custom_ami_private_key_file: "{{ setup_rsa_keys__private_key_file }}"
   block:
     # Test: create custom AMI
     - name: Create AMI with initial settings


### PR DESCRIPTION
Integration test target `test_customized_ami` is failing due to missing RSA keys files `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`
This pull request add a new test role to generate RSA keys prior to running integration tests.

This has been tested via pull request https://github.com/redhat-cop/cloud.aws_ops/pull/47