### PR TITLE
Enforce security using safe to test job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,21 +1,104 @@
 name: Integration
 on:
   pull_request_target:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
-  test:
+  safe-to-test:
+    if: ${{ github.event.label.name == 'safe to test' }} || ${{ github.event.action != 'labeled' }}
+    uses: abikouo/github_actions/.github/workflows/safe-to-test.yml@safe_to_test_v2
+  splitter:
     runs-on: ubuntu-latest
+    needs:
+      - safe-to-test
+    env:
+      source_dir: "cloud_awsops"
+    outputs:
+      test_targets: ${{ steps.display.outputs.test_targets }}
+    steps:
+      - name: Checkout collection
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.source_dir }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: "0"
+
+      - name: List changes for pull request
+        id: splitter
+        uses: abikouo/github_actions/.github/actions/ansible_test_splitter@splitter_for_roles
+        with:
+          collections_to_test: ${{ env.source_dir }}
+          total_jobs: 3
+
+      - name: display targets
+        id: display
+        run: echo "test_targets=${{ steps.splitter.outputs.test_targets }}" >> $GITHUB_OUTPUT
+        shell: bash
+  build_matrix:
+    runs-on: ubuntu-latest
+    if: ${{ needs.splitter.outputs.test_targets != '' }}
+    needs:
+      - splitter
+    outputs:
+      test_matrix: ${{ steps.compute-matrix.outputs.test_matrix }}
+      test_targets: ${{ needs.splitter.outputs.test_targets }}
+    steps:
+      - name: Compute matrix
+        id: compute-matrix
+        run: |
+          import os, json
+          test_matrix=[
+            item.split(":", maxsplit=1)[0].split('-', maxsplit=1)[1]
+            for item in os.environ.get('TEST_TARGETS').split(';') if item.split(':', maxsplit=1)[1]
+          ]
+          output_path = os.environ.get('GITHUB_OUTPUT')
+          with open(output_path, "a", encoding="utf-8") as fw:
+              fw.write(f'test_matrix={json.dumps(test_matrix)}\n')
+        shell: python
+        env:
+          TEST_TARGETS: ${{ needs.splitter.outputs.test_targets }}
+  test:
+    if: ${{ needs.build_matrix.outputs.test_matrix != '' }}
+    runs-on: ubuntu-latest
+    needs:
+      - build_matrix
     env:
       source: "./source"
       aws_dir: "./amazon_aws"
       crypto_dir: "./community.crypto"
       ansible_version: "stable-2.14"
       python_version: "3.9"
+    strategy:
+      fail-fast: false
+      matrix:
+        workflow-id: ${{ fromJson(needs.build_matrix.outputs.test_matrix) }}
+    name: "Integration-cloud.aws_ops-${{ matrix.workflow-id }}"
     steps:
+      - name: Read ansible-test targets
+        id: read-targets
+        run: |
+          import os
+          workflow_test_prefix = "cloud.aws_ops-{0}:".format(os.environ.get('TEST_WORKFLOW_ID'))
+          for item in os.environ.get('TEST_TARGETS').split(';'):
+              if item.startswith(workflow_test_prefix):
+                  targets=' '.join(item.split(':', maxsplit=1)[1].split(','))
+                  output_path = os.environ.get('GITHUB_OUTPUT')
+                  with open(output_path, "a", encoding="utf-8") as fw:
+                      fw.write(f"ansible_test_targets={targets}\n")
+        shell: python
+        env:
+          TEST_WORKFLOW_ID: "${{ matrix.workflow-id }}"
+          TEST_TARGETS: ${{ needs.build_matrix.outputs.test_targets }}
+
       - name: Checkout collection
         uses: actions/checkout@v3
         with:
           path: ${{ env.source }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and install collection
         id: install-collection
@@ -73,3 +156,4 @@ jobs:
           python_version: ${{ env.python_version }}
           ansible_version: ${{ env.ansible_version }}
           ansible_test_requirement_files: 'test-requirements.txt'
+          ansible_test_targets: ${{ steps.read-targets.outputs.ansible_test_targets }}


### PR DESCRIPTION
- `safe-to-test` protects repository from malicious contributors, when pull request is opened by a collaborator (user with maintain, admin or write role), Bot will automatically add `safe to test` label and integration will be executed, if not a repository collaborator needs to manually add the label to pull request in order for it to run

- `splitter` this job identifies the tests impacted by the change so that we do not need to run the full test suite for every single pull request