### PR TITLE
Fix: Integration tests test_customized_ami

### DIFF
--- a/roles/customized_ami/tasks/create.yaml
+++ b/roles/customized_ami/tasks/create.yaml
@@ -1,8 +1,27 @@
 ---
+- name: List existing AMI by name
+  amazon.aws.ec2_ami_info:
+    filters:
+      name: "{{ custom_ami_name }}"
+  register: customized_ami__existing_amis
+
 - name: Delete existing images
-  ansible.builtin.include_tasks: delete.yaml
+  amazon.aws.ec2_ami:
+    name: "{{ item.name }}"
+    image_id: "{{ item.image_id }}"
+    wait: true
+    state: absent
+  with_items: "{{ customized_ami__existing_amis.images }}"
+  when: custom_ami_recreate_if_exists | bool
+
+- name: List existing AMI by name
+  amazon.aws.ec2_ami_info:
+    filters:
+      name: "{{ custom_ami_name }}"
+  register: customized_ami__existing_amis
 
 - name: Create custom AMI
+  when: customized_ami__existing_amis.images | length == 0
   block:
     - name: Get Source AMI identifier
       ansible.builtin.include_tasks: read_source_ami.yaml
@@ -22,4 +41,3 @@
     msg: "Existing AMI found with name: '{{ custom_ami_name }}'"
   when:
     - customized_ami__existing_amis.images | length > 0
-    - not (custom_ami_recreate_if_exists | bool)

--- a/roles/customized_ami/tasks/delete.yaml
+++ b/roles/customized_ami/tasks/delete.yaml
@@ -12,6 +12,3 @@
     wait: true
     state: absent
   with_items: "{{ customized_ami__existing_amis.images }}"
-  when:
-    - customized_ami__existing_amis.images | length > 0
-    - (custom_ami_operation == 'create') | ternary(custom_ami_recreate_if_exists, 'true') | bool


### PR DESCRIPTION
Fix use case when trying to create existing AMI with `custom_ami_recreate_if_exists` set to `false`