### PR TITLE
Fix operation always defaulting to create in webapp

### DIFF
--- a/changelogs/fragments/20230707-webapp-fix_create_option.yml
+++ b/changelogs/fragments/20230707-webapp-fix_create_option.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - webapp - defaults to create when the user does not explicitly specify the operation (https://github.com/redhat-cop/cloud.aws_ops/pull/53).

--- a/playbooks/webapp/vars/main.yaml
+++ b/playbooks/webapp/vars/main.yaml
@@ -48,7 +48,7 @@ rds_allocated_storage_gb: 20
 rds_instance_class: db.m6g.large
 rds_instance_name: mysampledb123
 rds_engine: postgres
-rds_engine_version: "14.2"
+rds_engine_version: "15"
 rds_master_password: L#5cH2mgy_
 rds_master_user: ansible
 

--- a/playbooks/webapp/vars/main.yaml
+++ b/playbooks/webapp/vars/main.yaml
@@ -53,5 +53,3 @@ rds_master_password: L#5cH2mgy_
 rds_master_user: ansible
 
 image_filter: Fedora-Cloud-Base-35-*
-
-operation: create

--- a/playbooks/webapp/webapp.yaml
+++ b/playbooks/webapp/webapp.yaml
@@ -12,8 +12,13 @@
         msg: resource prefix should be defined as resource_prefix
       when: resource_prefix is not defined
 
+    - name: Fall to 'create' when operation is not defined
+      ansible.builtin.set_fact:
+        operation: create
+      when: operation is not defined
+
     - name: Run operation create/delete
-      ansible.builtin.import_tasks: tasks/{{ operation }}.yaml
+      ansible.builtin.import_tasks: "tasks/{{ operation }}.yaml"
 
 - name: Deploy resource from Bastion
   hosts: bastion


### PR DESCRIPTION
Even if I try to set operation=delete, it always defaults to create (because the passed value is overwritten by vars files.)

```
- import_playbook: cloud.aws_ops.webapp.webapp
  vars:
      operation: "delete"
      aws_access_key: "xxx
      aws_secret_key: "xxx"
      aws_region: "eu-central-1"
      resource_prefix: "demo"
```

This fix defaults to create when the user does not explicitly specify the operation.