### PR TITLE
Add 3.9 to exclude from devel

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -68,6 +68,10 @@ jobs:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
   all_green:


### PR DESCRIPTION
Add an exclude for 3.9 to devel to avoid sanity test failures on devel
example: https://github.com/redhat-cop/cloud.aws_ops/actions/runs/5511317186/jobs/10048840426