### PR TITLE
manage_vpc_peering: fix integration tests, update role var names

### DIFF
--- a/changelogs/fragments/fix_manage_vpc_peering_integration_test.yml
+++ b/changelogs/fragments/fix_manage_vpc_peering_integration_test.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix and update integration tests target test_manage_vpc_peering (https://github.com/redhat-cop/cloud.aws_ops/pull/61).

--- a/roles/manage_vpc_peering/README.md
+++ b/roles/manage_vpc_peering/README.md
@@ -4,21 +4,21 @@ A role to create, delete and accept existing VPC peering connections.
 
 ## Specify following values in role vars
 
-- region - Region of the requester VPC.
+- manage_vpc_peering_region - Region of the requester VPC.
 
-- requester_vpc - ID of the VPC requesting the peering connection.
+- manage_vpc_peering_requeter_vpc - ID of the VPC requesting the peering connection.
 
-- accepter_vpc - ID of the VPC accepting the peering connection.
+- manage_vpc_peering_accepter_vpc - ID of the VPC accepting the peering connection.
 
-- accepter_vpc_region - Region of the accepter VPC (Required if requester and accepter VPCs are in different regions or performing cross-account peering.)
+- manage_vpc_peering_accepter_vpc_region - Region of the accepter VPC (Required if requester and accepter VPCs are in different regions or performing cross-account peering.)
 
-- accepter_vpc_account_id - The AWS account ID of accepter VPC account for cross-account peering.
+- manage_vpc_peering_accepter_vpc_account_id - The AWS account ID of accepter VPC account for cross-account peering.
 
-- accepter_account_profile - A Named AWS profile of accepter VPC account for cross-account peering.
+- manage_vpc_peering_accepter_account_profile - A Named AWS profile of accepter VPC account for cross-account peering.
 
-- vpc_peering_operation - Choices include 'create', 'delete', and 'accept'.
+- manage_vpc_peering_operation - Choices include 'create', 'delete', and 'accept'.
 
-- vpc_peering_conn_id - ID of the VPC peering connection request (only provide to delete a VPC peering connection).
+- manage_vpc_peering_vpc_peering_conn_id - ID of the VPC peering connection request (only provide to delete a VPC peering connection).
 
 Return Value
 ------------
@@ -41,9 +41,9 @@ Dependencies
         name: cloud.aws_ops.manage_vpc_peering
       vars:
         region: us-west-1
-        requester_vpc: vpc-12345
-        accepter_vpc: vpc-98765
-        vpc_peering_operation: create
+        manage_vpc_peering_requeter_vpc: vpc-12345
+        manage_vpc_peering_accepter_vpc: vpc-98765
+        manage_vpc_peering_operation: create
 
     - name: Set variable for peering connection ID for above task
       ansible.builtin.set_fact:
@@ -54,48 +54,48 @@ Dependencies
         name: cloud.aws_ops.manage_vpc_peering
       vars:
         region: us-west-1
-        requester_vpc: vpc-12345
-        accepter_vpc: vpc-98765
-        accepter_vpc_region: ap-northeast-3
-        vpc_peering_operation: create
+        manage_vpc_peering_requeter_vpc: vpc-12345
+        manage_vpc_peering_accepter_vpc: vpc-98765
+        manage_vpc_peering_accepter_vpc_region: ap-northeast-3
+        manage_vpc_peering_operation: create
 
     - name: Peer VPCs in different accounts and different region (cross-account)
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
       vars:
         region: us-west-1
-        requester_vpc: vpc-12345
-        accepter_vpc: vpc-98765
-        accepter_vpc_region: ap-northeast-3
-        accepter_vpc_account_id: 1234567890
-        accepter_account_profile: my-account-profile
-        vpc_peering_operation: create
+        manage_vpc_peering_requeter_vpc: vpc-12345
+        manage_vpc_peering_accepter_vpc: vpc-98765
+        manage_vpc_peering_accepter_vpc_region: ap-northeast-3
+        manage_vpc_peering_accepter_vpc_account_id: 1234567890
+        manage_vpc_peering_accepter_account_profile: my-account-profile
+        manage_vpc_peering_operation: create
 
     - name: Delete VPC peering request
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
       vars:
         region: us-west-1
-        vpc_peering_conn_id: pcx-1234567890
-        vpc_peering_operation: delete
+        manage_vpc_peering_vpc_peering_conn_id: pcx-1234567890
+        manage_vpc_peering_operation: delete
 
     - name: Accept existing VPC peering request (local account)
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
       vars:
         region: us-west-1
-        vpc_peering_conn_id: pcx-1234567890
-        vpc_peering_operation: accept
+        manage_vpc_peering_vpc_peering_conn_id: pcx-1234567890
+        manage_vpc_peering_operation: accept
 
     - name: Accept existing VPC peering request (another account)
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
       vars:
         region: us-west-1
-        vpc_peering_conn_id: pcx-1234567890
-        vpc_peering_operation: accept
-        accepter_vpc_account_id: 1234567890
-        accepter_account_profile: my-account-profile
+        manage_vpc_peering_vpc_peering_conn_id: pcx-1234567890
+        manage_vpc_peering_operation: accept
+        manage_vpc_peering_accepter_vpc_account_id: 1234567890
+        manage_vpc_peering_accepter_account_profile: my-account-profile
 ```
 
 License

--- a/roles/manage_vpc_peering/tasks/accept.yaml
+++ b/roles/manage_vpc_peering/tasks/accept.yaml
@@ -2,16 +2,16 @@
 - name: Fail when required parameters are not provided
   ansible.builtin.fail:
     msg: Please provide required parameters to create VPC peering (refer documentation for more information)
-  when: region is not defined or vpc_peering_conn_id is not defined
+  when: manage_vpc_peering_region is not defined or manage_vpc_peering_vpc_peering_conn_id is not defined
 
 - name: Accept VPC peering connection request
   block:
     - name: Ensure VPC peering connection request exists before moving forward
       community.aws.ec2_vpc_peering_info:
         peer_connection_ids:
-          - "{{ vpc_peering_conn_id }}"
-        region: "{{ region }}"
-        profile: "{{ accepter_account_profile | default(omit) }}"
+          - "{{ manage_vpc_peering_vpc_peering_conn_id }}"
+        region: "{{ manage_vpc_peering_region }}"
+        profile: "{{ manage_vpc_peering_accepter_account_profile | default(omit) }}"
       register: manage_vpc_peering_peering_info
       retries: 3
       delay: 5
@@ -19,9 +19,9 @@
 
     - name: Accept VPC peering request
       community.aws.ec2_vpc_peer:
-        region: "{{ region }}"
-        peering_id: "{{ vpc_peering_conn_id }}"
-        peer_owner_id: "{{ accepter_vpc_account_id | default(omit) }}"
-        profile: "{{ accepter_account_profile | default(omit) }}"
+        region: "{{ manage_vpc_peering_region }}"
+        peering_id: "{{ manage_vpc_peering_vpc_peering_conn_id }}"
+        peer_owner_id: "{{ manage_vpc_peering_accepter_vpc_account_id | default(omit) }}"
+        profile: "{{ manage_vpc_peering_accepter_account_profile | default(omit) }}"
         state: accept
       register: manage_vpc_peering_accept_peering_request

--- a/roles/manage_vpc_peering/tasks/create.yaml
+++ b/roles/manage_vpc_peering/tasks/create.yaml
@@ -2,17 +2,17 @@
 - name: Fail when required parameters are not provided
   ansible.builtin.fail:
     msg: Please provide required parameters to create VPC peering (refer documentation for more information)
-  when: region is not defined or requester_vpc is not defined or accepter_vpc is not defined
+  when: manage_vpc_peering_region is not defined or manage_vpc_peering_requeter_vpc is not defined or manage_vpc_peering_accepter_vpc is not defined
 
 - name: Create VPC peering
   block:
     - name: Create VPC peering request
       community.aws.ec2_vpc_peer:
-        region: "{{ region }}"
-        peer_region: "{{ accepter_vpc_region | default(region, true) }}"
-        vpc_id: "{{ requester_vpc }}"
-        peer_vpc_id: "{{ accepter_vpc }}"
-        peer_owner_id: "{{ accepter_vpc_account_id | default(omit) }}"
+        region: "{{ manage_vpc_peering_region }}"
+        peer_region: "{{ manage_vpc_peering_accepter_vpc_region | default(manage_vpc_peering_region, true) }}"
+        vpc_id: "{{ manage_vpc_peering_requeter_vpc }}"
+        peer_vpc_id: "{{ manage_vpc_peering_accepter_vpc }}"
+        peer_owner_id: "{{ manage_vpc_peering_accepter_vpc_account_id | default(omit) }}"
         state: present
       register: manage_vpc_peering_vpc_peering_request
 
@@ -20,8 +20,8 @@
       community.aws.ec2_vpc_peering_info:
         peer_connection_ids:
           - "{{ manage_vpc_peering_vpc_peering_request.peering_id }}"
-        region: "{{ accepter_vpc_region | default(region, true) }}"
-        profile: "{{ accepter_account_profile | default(omit) }}"
+        region: "{{ manage_vpc_peering_accepter_vpc_region | default(manage_vpc_peering_region, true) }}"
+        profile: "{{ manage_vpc_peering_accepter_account_profile | default(omit) }}"
       register: manage_vpc_peering_peering_info
       retries: 3
       delay: 5
@@ -33,10 +33,10 @@
 
     - name: Accept VPC peering request
       community.aws.ec2_vpc_peer:
-        region: "{{ accepter_vpc_region | default(region, true) }}"
+        region: "{{ manage_vpc_peering_accepter_vpc_region | default(manage_vpc_peering_region, true) }}"
         peering_id: "{{ manage_vpc_peering_vpc_peering_request.peering_id }}"
-        peer_owner_id: "{{ accepter_vpc_account_id | default(omit) }}"
-        profile: "{{ accepter_account_profile | default(omit) }}"
+        peer_owner_id: "{{ manage_vpc_peering_accepter_vpc_account_id | default(omit) }}"
+        profile: "{{ manage_vpc_peering_accepter_account_profile | default(omit) }}"
         state: accept
       register: manage_vpc_peering_accept_peering_request
 

--- a/roles/manage_vpc_peering/tasks/delete.yaml
+++ b/roles/manage_vpc_peering/tasks/delete.yaml
@@ -2,14 +2,14 @@
 - name: Fail when required parameters are not provided
   ansible.builtin.fail:
     msg: Please provide required parameters to delete VPC peering (refer documentation for more information)
-  when: region is not defined or vpc_peering_conn_id is not defined
+  when: manage_vpc_peering_region is not defined or manage_vpc_peering_vpc_peering_conn_id is not defined
 
 - name: Delete vpc peering connection request
   block:
     - name: Delete a local VPC peering connection
       community.aws.ec2_vpc_peer:
-        region: "{{ region }}"
-        peering_id: "{{ vpc_peering_conn_id }}"
+        region: "{{ manage_vpc_peering_region }}"
+        peering_id: "{{ manage_vpc_peering_vpc_peering_conn_id }}"
         state: absent
       register: manage_vpc_peering_vpc_peer
 

--- a/roles/manage_vpc_peering/tasks/main.yaml
+++ b/roles/manage_vpc_peering/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Run 'manage_vpc_peering' role
   module_defaults:
-    group/aws: "{{ aws_role_credentials }}"
+    group/aws: "{{ aws_setup_credentials__output }}"
 
   block:
     - name: Include file

--- a/roles/manage_vpc_peering/tasks/main.yaml
+++ b/roles/manage_vpc_peering/tasks/main.yaml
@@ -5,4 +5,4 @@
 
   block:
     - name: Include file
-      ansible.builtin.include_tasks: "{{ vpc_peering_operation }}.yaml"
+      ansible.builtin.include_tasks: "{{ manage_vpc_peering_operation }}.yaml"

--- a/tests/integration/targets/test_manage_vpc_peering/aliases
+++ b/tests/integration/targets/test_manage_vpc_peering/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 role/manage_vpc_peering
-time=10s
+time=1m

--- a/tests/integration/targets/test_manage_vpc_peering/aliases
+++ b/tests/integration/targets/test_manage_vpc_peering/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+role/manage_vpc_peering
+time=10s

--- a/tests/integration/targets/test_manage_vpc_peering/defaults/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/defaults/main.yml
@@ -2,10 +2,12 @@
 # defaults file for manage_vpc_peering role
 aws_security_token: '{{ security_token | default(omit) }}'
 
-test_vpc_name_1_1: role_test_vpc_1_1
-test_vpc_name_1_2: role_test_vpc_1_2
-# test_vpc_name_2: role_test_vpc_2
+test_vpc_name_1: "{{ resource_prefix }}-vpc-1"
+test_vpc_cidr_1: '172.{{ 255 | random(seed=resource_prefix) }}.0.0/28'
 
-test_vpc_cidr_1_1: 172.10.0.0/16
-test_vpc_cidr_1_2: 192.168.0.0/28
-# test_vpc_cidr_2_1: 192.168.64.0/26
+test_vpc_name_2: "{{ resource_prefix }}-vpc-2"
+test_vpc_cidr_2: '192.{{ 255 | random(seed=resource_prefix) }}.0.0/28'
+
+# Disable: IAM permission does not allow to create VPC into a region different than the one
+# test_vpc_name_3: "{{ resource_prefix }}-vpc-3"
+# test_vpc_cidr_3: '192.{{ 255 | random(seed=resource_prefix) }}.64.0/28'

--- a/tests/integration/targets/test_manage_vpc_peering/defaults/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 # defaults file for manage_vpc_peering role
+aws_security_token: '{{ security_token | default(omit) }}'
 
 test_vpc_name_1_1: role_test_vpc_1_1
 test_vpc_name_1_2: role_test_vpc_1_2
-test_vpc_name_2: role_test_vpc_2
+# test_vpc_name_2: role_test_vpc_2
 
 test_vpc_cidr_1_1: 172.10.0.0/16
 test_vpc_cidr_1_2: 192.168.0.0/28
-test_vpc_cidr_2_1: 192.168.64.0/26
+# test_vpc_cidr_2_1: 192.168.64.0/26

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/create_delete_accept_peering.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/create_delete_accept_peering.yml
@@ -1,0 +1,63 @@
+---
+# Test: create and accept VPC peering
+- name: Create and accept VPC peering
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    requester_vpc: "{{ vpc_peering_requester_vpc_id }}"
+    accepter_vpc: "{{ vpc_peering_accepter_vpc_id }}"
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_operation: create
+
+- name: Validate that VPC Peering was created and is active
+  ansible.builtin.include_tasks: validate.yml
+
+# Test: delete existing VPC peering
+- name: Delete VPC peering connection request
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
+    vpc_peering_operation: delete
+
+- name: Validate that VPC Peering was deleted
+  ansible.builtin.include_tasks: validate.yml
+  vars:
+    vpc_peering_status: "deleted"
+
+# Test: accept existing VPC peering request
+- name: Create VPC peering request
+  community.aws.ec2_vpc_peer:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token | default(omit) }}"
+    region: "{{ aws_region }}"
+    peer_region: "{{ vpc_peering_accepter_region }}"
+    vpc_id: "{{ vpc_peering_requester_vpc_id }}"
+    peer_vpc_id: "{{ vpc_peering_accepter_vpc_id }}"
+    state: present
+  register: __vpc_peering
+
+- name: Set Peering id into variable
+  ansible.builtin.set_fact:
+    vpc_peering_id: "{{ __vpc_peering.peering_id }}"
+
+- name: Accept existing VPC peering request
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_conn_id: "{{ vpc_peering_id }}"
+    vpc_peering_operation: accept
+
+- name: Validate that VPC Peering has been accepted
+  ansible.builtin.include_tasks: validate.yml
+
+- name: Delete VPC peering connection
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_conn_id: "{{ vpc_peering_id }}"
+    vpc_peering_operation: delete

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/create_delete_accept_peering.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/create_delete_accept_peering.yml
@@ -4,10 +4,10 @@
   ansible.builtin.include_role:
     name: cloud.aws_ops.manage_vpc_peering
   vars:
-    requester_vpc: "{{ vpc_peering_requester_vpc_id }}"
-    accepter_vpc: "{{ vpc_peering_accepter_vpc_id }}"
-    region: "{{ vpc_peering_accepter_region }}"
-    vpc_peering_operation: create
+    manage_vpc_peering_requeter_vpc: "{{ vpc_peering_manage_vpc_peering_requeter_vpc_id }}"
+    manage_vpc_peering_accepter_vpc: "{{ vpc_peering_manage_vpc_peering_accepter_vpc_id }}"
+    manage_vpc_peering_region: "{{ vpc_peering_accepter_region }}"
+    manage_vpc_peering_operation: create
 
 - name: Validate that VPC Peering was created and is active
   ansible.builtin.include_tasks: validate.yml
@@ -17,9 +17,9 @@
   ansible.builtin.include_role:
     name: cloud.aws_ops.manage_vpc_peering
   vars:
-    region: "{{ vpc_peering_accepter_region }}"
-    vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-    vpc_peering_operation: delete
+    manage_vpc_peering_region: "{{ vpc_peering_accepter_region }}"
+    manage_vpc_peering_vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
+    manage_vpc_peering_operation: delete
 
 - name: Validate that VPC Peering was deleted
   ansible.builtin.include_tasks: validate.yml
@@ -34,8 +34,8 @@
     aws_security_token: "{{ security_token | default(omit) }}"
     region: "{{ aws_region }}"
     peer_region: "{{ vpc_peering_accepter_region }}"
-    vpc_id: "{{ vpc_peering_requester_vpc_id }}"
-    peer_vpc_id: "{{ vpc_peering_accepter_vpc_id }}"
+    vpc_id: "{{ vpc_peering_manage_vpc_peering_requeter_vpc_id }}"
+    peer_vpc_id: "{{ vpc_peering_manage_vpc_peering_accepter_vpc_id }}"
     state: present
   register: __vpc_peering
 
@@ -47,9 +47,9 @@
   ansible.builtin.include_role:
     name: cloud.aws_ops.manage_vpc_peering
   vars:
-    region: "{{ vpc_peering_accepter_region }}"
-    vpc_peering_conn_id: "{{ vpc_peering_id }}"
-    vpc_peering_operation: accept
+    manage_vpc_peering_region: "{{ vpc_peering_accepter_region }}"
+    manage_vpc_peering_vpc_peering_conn_id: "{{ vpc_peering_id }}"
+    manage_vpc_peering_operation: accept
 
 - name: Validate that VPC Peering has been accepted
   ansible.builtin.include_tasks: validate.yml
@@ -58,6 +58,6 @@
   ansible.builtin.include_role:
     name: cloud.aws_ops.manage_vpc_peering
   vars:
-    region: "{{ vpc_peering_accepter_region }}"
-    vpc_peering_conn_id: "{{ vpc_peering_id }}"
-    vpc_peering_operation: delete
+    manage_vpc_peering_region: "{{ vpc_peering_accepter_region }}"
+    manage_vpc_peering_vpc_peering_conn_id: "{{ vpc_peering_id }}"
+    manage_vpc_peering_operation: delete

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -15,8 +15,8 @@
     - name: Test VPC Peering in the same region
       ansible.builtin.include_tasks: create_delete_accept_peering.yml
       vars:
-        vpc_peering_accepter_vpc_id: "{{ test_vpc_1.vpc.id }}"
-        vpc_peering_requester_vpc_id: "{{ test_vpc_2.vpc.id }}"
+        vpc_peering_manage_vpc_peering_accepter_vpc_id: "{{ test_vpc_1.vpc.id }}"
+        vpc_peering_manage_vpc_peering_requeter_vpc_id: "{{ test_vpc_2.vpc.id }}"
         vpc_peering_accepter_region: "{{ aws_region }}"
 
   # Disable: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
@@ -25,19 +25,19 @@
   #   ansible.builtin.include_role:
   #     name: cloud.aws_ops.manage_vpc_peering
   #   vars:
-  #     region: "{{ aws_region }}"
-  #     accepter_vpc_region: us-west-1
-  #     requester_vpc: "{{ test_vpc_1.vpc.id }}"
-  #     accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
-  #     vpc_peering_operation: create
+  #     manage_vpc_peering_region: "{{ aws_region }}"
+  #     manage_vpc_peering_accepter_vpc_region: us-west-1
+  #     manage_vpc_peering_requeter_vpc: "{{ test_vpc_1.vpc.id }}"
+  #     manage_vpc_peering_accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
+  #     manage_vpc_peering_operation: create
 
   # - name: Delete VPC peering connection req
   #   ansible.builtin.include_role:
   #     name: cloud.aws_ops.manage_vpc_peering
   #   vars:
-  #     region: "{{ aws_region }}"
-  #     vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-  #     vpc_peering_operation: delete
+  #     manage_vpc_peering_region: "{{ aws_region }}"
+  #     manage_vpc_peering_vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
+  #     manage_vpc_peering_operation: delete
 
   always:
     - name: Include 'teardown.yml' file

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -11,35 +11,23 @@
     - name: Include 'setup.yml' file
       ansible.builtin.include_tasks: setup.yml
 
-    # VPC Peering (same region)
-    - name: Create VPC peering (same region)
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
-      # noqa: var-naming[no-role-prefix]
-      vars:
-        requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
-        accepter_vpc: "{{ us_east_1_vpc_2.vpc.id }}"
-        region: us-east-1
-        vpc_peering_operation: create
 
-    - name: Delete VPC peering connection req
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
-      # noqa: var-naming[no-role-prefix]
+    - name: Test VPC Peering in the same region
+      ansible.builtin.include_tasks: create_delete_accept_peering.yml
       vars:
-        region: us-east-1
-        vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-        vpc_peering_operation: delete
+        vpc_peering_accepter_vpc_id: "{{ test_vpc_1.vpc.id }}"
+        vpc_peering_requester_vpc_id: "{{ test_vpc_2.vpc.id }}"
+        vpc_peering_accepter_region: "{{ aws_region }}"
 
-  # NOTE: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
+  # Disable: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
   #  VPC Peering (cross region)
   # - name: Create VPC peering (cross region)
   #   ansible.builtin.include_role:
   #     name: cloud.aws_ops.manage_vpc_peering
   #   vars:
-  #     region: us-east-1
+  #     region: "{{ aws_region }}"
   #     accepter_vpc_region: us-west-1
-  #     requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
+  #     requester_vpc: "{{ test_vpc_1.vpc.id }}"
   #     accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
   #     vpc_peering_operation: create
 
@@ -47,7 +35,7 @@
   #   ansible.builtin.include_role:
   #     name: cloud.aws_ops.manage_vpc_peering
   #   vars:
-  #     region: us-east-1
+  #     region: "{{ aws_region }}"
   #     vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
   #     vpc_peering_operation: delete
 

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -15,6 +15,7 @@
     - name: Create VPC peering (same region)
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
+      # noqa: var-naming[no-role-prefix]
       vars:
         requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
         accepter_vpc: "{{ us_east_1_vpc_2.vpc.id }}"
@@ -24,30 +25,31 @@
     - name: Delete VPC peering connection req
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
+      # noqa: var-naming[no-role-prefix]
       vars:
         region: us-east-1
         vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
         vpc_peering_operation: delete
 
   # NOTE: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
-    #  VPC Peering (cross region)
-    # - name: Create VPC peering (cross region)
-    #   ansible.builtin.include_role:
-    #     name: cloud.aws_ops.manage_vpc_peering
-    #   vars:
-    #     region: us-east-1
-    #     accepter_vpc_region: us-west-1
-    #     requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
-    #     accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
-    #     vpc_peering_operation: create
+  #  VPC Peering (cross region)
+  # - name: Create VPC peering (cross region)
+  #   ansible.builtin.include_role:
+  #     name: cloud.aws_ops.manage_vpc_peering
+  #   vars:
+  #     region: us-east-1
+  #     accepter_vpc_region: us-west-1
+  #     requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
+  #     accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
+  #     vpc_peering_operation: create
 
-    # - name: Delete VPC peering connection req
-    #   ansible.builtin.include_role:
-    #     name: cloud.aws_ops.manage_vpc_peering
-    #   vars:
-    #     region: us-east-1
-    #     vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-    #     vpc_peering_operation: delete
+  # - name: Delete VPC peering connection req
+  #   ansible.builtin.include_role:
+  #     name: cloud.aws_ops.manage_vpc_peering
+  #   vars:
+  #     region: us-east-1
+  #     vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
+  #     vpc_peering_operation: delete
 
   always:
     - name: Include 'teardown.yml' file

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -29,7 +29,7 @@
         vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
         vpc_peering_operation: delete
 
-    # NOTE: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
+  # NOTE: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
     #  VPC Peering (cross region)
     # - name: Create VPC peering (cross region)
     #   ansible.builtin.include_role:

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -16,37 +16,38 @@
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
       vars:
-        requester_vpc: "{{ eu_central_1_vpc_1.vpc.id }}"
-        accepter_vpc: "{{ eu_central_1_vpc_2.vpc.id }}"
-        region: eu-central-1
+        requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
+        accepter_vpc: "{{ us_east_1_vpc_2.vpc.id }}"
+        region: us-east-1
         vpc_peering_operation: create
 
     - name: Delete VPC peering connection req
       ansible.builtin.include_role:
         name: cloud.aws_ops.manage_vpc_peering
       vars:
-        region: eu-central-1
+        region: us-east-1
         vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
         vpc_peering_operation: delete
 
+    # NOTE: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
     #  VPC Peering (cross region)
-    - name: Create VPC peering (cross region)
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
-      vars:
-        region: eu-central-1
-        accepter_vpc_region: us-west-1
-        requester_vpc: "{{ eu_central_1_vpc_1.vpc.id }}"
-        accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
-        vpc_peering_operation: create
+    # - name: Create VPC peering (cross region)
+    #   ansible.builtin.include_role:
+    #     name: cloud.aws_ops.manage_vpc_peering
+    #   vars:
+    #     region: us-east-1
+    #     accepter_vpc_region: us-west-1
+    #     requester_vpc: "{{ us_east_1_vpc_1.vpc.id }}"
+    #     accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
+    #     vpc_peering_operation: create
 
-    - name: Delete VPC peering connection req
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
-      vars:
-        region: eu-central-1
-        vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-        vpc_peering_operation: delete
+    # - name: Delete VPC peering connection req
+    #   ansible.builtin.include_role:
+    #     name: cloud.aws_ops.manage_vpc_peering
+    #   vars:
+    #     region: us-east-1
+    #     vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
+    #     vpc_peering_operation: delete
 
   always:
     - name: Include 'teardown.yml' file

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/setup.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/setup.yml
@@ -1,21 +1,22 @@
 ---
-- name: Create first VPC in us-east-1
+- name: Create first VPC
   amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_1 }}"
-    name: "{{ test_vpc_name_1_1 }}"
-    region: us-east-1
-  register: us_east_1_vpc_1
+    cidr_block: "{{ test_vpc_cidr_1 }}"
+    name: "{{ test_vpc_name_1 }}"
+    region: "{{ aws_region }}"
+  register: test_vpc_1
 
-- name: Create second VPC in us-east-1
+- name: Create second VPC
   amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_2 }}"
-    name: "{{ test_vpc_name_1_2 }}"
-    region: us-east-1
-  register: us_east_1_vpc_2
+    cidr_block: "{{ test_vpc_cidr_2 }}"
+    name: "{{ test_vpc_name_2 }}"
+    region: "{{ aws_region }}"
+  register: test_vpc_2
 
+# Disable: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
 # - name: Create VPC in us-west-1
 #   amazon.aws.ec2_vpc_net:
-#     cidr_block: "{{ test_vpc_cidr_2_1 }}"
-#     name: "{{ test_vpc_name_2 }}"
+#     cidr_block: "{{ test_vpc_cidr_3 }}"
+#     name: "{{ test_vpc_name_3 }}"
 #     region: us-west-1
 #   register: us_west_1_vpc_1

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/setup.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/setup.yml
@@ -1,21 +1,21 @@
 ---
-- name: Create first VPC in eu-central-1
+- name: Create first VPC in us-east-1
   amazon.aws.ec2_vpc_net:
     cidr_block: "{{ test_vpc_cidr_1_1 }}"
     name: "{{ test_vpc_name_1_1 }}"
-    region: eu-central-1
-  register: eu_central_1_vpc_1
+    region: us-east-1
+  register: us_east_1_vpc_1
 
-- name: Create second VPC in eu-central-1
+- name: Create second VPC in us-east-1
   amazon.aws.ec2_vpc_net:
     cidr_block: "{{ test_vpc_cidr_1_2 }}"
     name: "{{ test_vpc_name_1_2 }}"
-    region: eu-central-1
-  register: eu_central_1_vpc_2
+    region: us-east-1
+  register: us_east_1_vpc_2
 
-- name: Create VPC in us-west-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_2_1 }}"
-    name: "{{ test_vpc_name_2 }}"
-    region: us-west-1
-  register: us_west_1_vpc_1
+# - name: Create VPC in us-west-1
+#   amazon.aws.ec2_vpc_net:
+#     cidr_block: "{{ test_vpc_cidr_2_1 }}"
+#     name: "{{ test_vpc_name_2 }}"
+#     region: us-west-1
+#   register: us_west_1_vpc_1

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/teardown.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/teardown.yml
@@ -1,27 +1,27 @@
 ---
-- name: Delete first VPC in eu-central-1
+- name: Delete first VPC in us-east-1
   amazon.aws.ec2_vpc_net:
     cidr_block: "{{ test_vpc_cidr_1_1 }}"
     name: "{{ test_vpc_name_1_1 }}"
     state: absent
-    region: eu-central-1
-  register: eu_central_1_vpc_1
+    region: us-east-1
+  register: us_east_1_vpc_1
   ignore_errors: true
 
-- name: Delete second VPC in eu-central-1
+- name: Delete second VPC in us-east-1
   amazon.aws.ec2_vpc_net:
     cidr_block: "{{ test_vpc_cidr_1_2 }}"
     name: "{{ test_vpc_name_1_2 }}"
     state: absent
-    region: eu-central-1
-  register: eu_central_1_vpc_2
+    region: us-east-1
+  register: us_east_1_vpc_2
   ignore_errors: true
 
-- name: Delete VPC in us-west-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_2_1 }}"
-    name: "{{ test_vpc_name_2 }}"
-    state: absent
-    region: us-west-1
-  register: us_west_1_vpc_1
-  ignore_errors: true
+# - name: Delete VPC in us-west-1
+#   amazon.aws.ec2_vpc_net:
+#     cidr_block: "{{ test_vpc_cidr_2_1 }}"
+#     name: "{{ test_vpc_name_2 }}"
+#     state: absent
+#     region: us-west-1
+#   register: us_west_1_vpc_1
+#   ignore_errors: true

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/teardown.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/teardown.yml
@@ -1,27 +1,28 @@
 ---
-- name: Delete first VPC in us-east-1
+- name: Delete first VPC
   amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_1 }}"
-    name: "{{ test_vpc_name_1_1 }}"
+    cidr_block: "{{ test_vpc_cidr_1 }}"
+    name: "{{ test_vpc_name_1 }}"
+    region: "{{ aws_region }}"
     state: absent
-    region: us-east-1
-  register: us_east_1_vpc_1
+  register: test_vpc_1
   ignore_errors: true
 
-- name: Delete second VPC in us-east-1
+- name: Delete second VPC
   amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_2 }}"
-    name: "{{ test_vpc_name_1_2 }}"
+    cidr_block: "{{ test_vpc_cidr_2 }}"
+    name: "{{ test_vpc_name_2 }}"
+    region: "{{ aws_region }}"
     state: absent
-    region: us-east-1
-  register: us_east_1_vpc_2
+  register: test_vpc_2
   ignore_errors: true
 
+  # Disable: Tests for cross-region vpc peering skipped as CI permissions are restricted to us-east-1 only
 # - name: Delete VPC in us-west-1
 #   amazon.aws.ec2_vpc_net:
-#     cidr_block: "{{ test_vpc_cidr_2_1 }}"
-#     name: "{{ test_vpc_name_2 }}"
-#     state: absent
+#     cidr_block: "{{ test_vpc_cidr_3 }}"
+#     name: "{{ test_vpc_name_3 }}"
 #     region: us-west-1
+#     state: absent
 #   register: us_west_1_vpc_1
 #   ignore_errors: true

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/validate.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/validate.yml
@@ -1,13 +1,13 @@
 ---
 - name: Validate that VPC peering exist with status accepted
   module_defaults:
-      group/aws: "{{ aws_setup_credentials__output }}"
+    group/aws: "{{ aws_setup_credentials__output }}"
   block:
     - name: Check VPC peering
       community.aws.ec2_vpc_peering_info:
         filters:
-          requester-vpc-info.vpc-id: "{{ vpc_peering_requester_vpc_id }}"
-          accepter-vpc-info.vpc-id: "{{ vpc_peering_accepter_vpc_id }}"
+          requester-vpc-info.vpc-id: "{{ vpc_peering_manage_vpc_peering_requeter_vpc_id }}"
+          accepter-vpc-info.vpc-id: "{{ vpc_peering_manage_vpc_peering_accepter_vpc_id }}"
           status-code: "{{ vpc_peering_status | default('active') }}"
       register: __vpc_peering
 

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/validate.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/validate.yml
@@ -1,0 +1,17 @@
+---
+- name: Validate that VPC peering exist with status accepted
+  module_defaults:
+      group/aws: "{{ aws_setup_credentials__output }}"
+  block:
+    - name: Check VPC peering
+      community.aws.ec2_vpc_peering_info:
+        filters:
+          requester-vpc-info.vpc-id: "{{ vpc_peering_requester_vpc_id }}"
+          accepter-vpc-info.vpc-id: "{{ vpc_peering_accepter_vpc_id }}"
+          status-code: "{{ vpc_peering_status | default('active') }}"
+      register: __vpc_peering
+
+    - name: Validate that VPC peering was found as expected
+      ansible.builtin.assert:
+        that:
+          - __vpc_peering.result | length == 1


### PR DESCRIPTION
Fix integration tests for `manage_vpc_peering` role.