### PR TITLE
fix: integration test test_manage_vpc_peering

### DIFF
--- a/changelogs/fragments/fix_test_vpc_peering.yml
+++ b/changelogs/fragments/fix_test_vpc_peering.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix and update integration tests target test_manage_vpc_peering (https://github.com/redhat-cop/cloud.aws_ops/pull/67).

--- a/roles/manage_vpc_peering/tasks/main.yaml
+++ b/roles/manage_vpc_peering/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Run 'manage_vpc_peering' role
   module_defaults:
-    group/aws: "{{ aws_role_credentials }}"
+    group/aws: "{{ aws_setup_credentials__output }}"
 
   block:
     - name: Include file

--- a/tests/integration/targets/test_manage_vpc_peering/aliases
+++ b/tests/integration/targets/test_manage_vpc_peering/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+role/manage_vpc_peering
+time=30s

--- a/tests/integration/targets/test_manage_vpc_peering/aliases
+++ b/tests/integration/targets/test_manage_vpc_peering/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 role/manage_vpc_peering
-time=30s
+time=1m

--- a/tests/integration/targets/test_manage_vpc_peering/defaults/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/defaults/main.yml
@@ -1,10 +1,18 @@
 ---
 # defaults file for manage_vpc_peering role
+aws_security_token: '{{ security_token | default(omit) }}'
+test_vpc_region_1:
+  region: "{{ aws_region }}"
+  vpcs:
+    - cidr_block: '172.{{ 255 | random(seed=resource_prefix) }}.0.0/28'
+      name: '{{ resource_prefix }}-vpc-1'
+    - cidr_block: '192.{{ 255 | random(seed=resource_prefix) }}.0.0/28'
+      name: '{{ resource_prefix }}-vpc-2'
 
-test_vpc_name_1_1: role_test_vpc_1_1
-test_vpc_name_1_2: role_test_vpc_1_2
-test_vpc_name_2: role_test_vpc_2
-
-test_vpc_cidr_1_1: 172.10.0.0/16
-test_vpc_cidr_1_2: 192.168.0.0/28
-test_vpc_cidr_2_1: 192.168.64.0/26
+# Disable: IAM permission does not allow to create VPC into a region different than the one
+# defined into variable 'aws_region'
+# test_vpc_region_2:
+#   region: ""
+#   vpcs:
+#     - cidr_block: '10.{{ 255 | random(seed=resource_prefix) }}.0.0/28'
+#       name: '{{ resource_prefix }}-vpc-3'

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -1,52 +1,24 @@
 ---
 - name: Test 'manage_vpc_peering' role
-  module_defaults:
-    group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
-      region: "{{ aws_region }}"
-
   block:
     - name: Include 'setup.yml' file
       ansible.builtin.include_tasks: setup.yml
 
     # VPC Peering (same region)
-    - name: Create VPC peering (same region)
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
+    - name: Test VPC Peering in the same region
+      ansible.builtin.include_tasks: vpc_peering.yml
       vars:
-        requester_vpc: "{{ eu_central_1_vpc_1.vpc.id }}"
-        accepter_vpc: "{{ eu_central_1_vpc_2.vpc.id }}"
-        region: eu-central-1
-        vpc_peering_operation: create
+        vpc_peering_accepter_vpc_id: "{{ __vpcs_region1.results.0.vpc.id }}"
+        vpc_peering_requester_vpc_id: "{{ __vpcs_region1.results.1.vpc.id }}"
+        vpc_peering_accepter_region: "{{ test_vpc_region_1.region }}"
 
-    - name: Delete VPC peering connection req
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
+    # VPC Peering (different region)
+    - name: Test VPC Peering in the same region
+      ansible.builtin.include_tasks: vpc_peering.yml
       vars:
-        region: eu-central-1
-        vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-        vpc_peering_operation: delete
-
-    #  VPC Peering (cross region)
-    - name: Create VPC peering (cross region)
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
-      vars:
-        region: eu-central-1
-        accepter_vpc_region: us-west-1
-        requester_vpc: "{{ eu_central_1_vpc_1.vpc.id }}"
-        accepter_vpc: "{{ us_west_1_vpc_1.vpc.id }}"
-        vpc_peering_operation: create
-
-    - name: Delete VPC peering connection req
-      ansible.builtin.include_role:
-        name: cloud.aws_ops.manage_vpc_peering
-      vars:
-        region: eu-central-1
-        vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
-        vpc_peering_operation: delete
+        vpc_peering_accepter_vpc_id: "{{ __vpcs_region2.results.0.vpc.id }}"
+        vpc_peering_requester_vpc_id: "{{ __vpcs_region1.results.0.vpc.id }}"
+        vpc_peering_accepter_region: "{{ test_vpc_region_2.region }}"
 
   always:
     - name: Include 'teardown.yml' file

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/main.yml
@@ -13,12 +13,13 @@
         vpc_peering_accepter_region: "{{ test_vpc_region_1.region }}"
 
     # VPC Peering (different region)
-    - name: Test VPC Peering in the same region
+    - name: Test VPC Peering in different region
       ansible.builtin.include_tasks: vpc_peering.yml
       vars:
         vpc_peering_accepter_vpc_id: "{{ __vpcs_region2.results.0.vpc.id }}"
         vpc_peering_requester_vpc_id: "{{ __vpcs_region1.results.0.vpc.id }}"
         vpc_peering_accepter_region: "{{ test_vpc_region_2.region }}"
+      when: test_vpc_region_2 is defined
 
   always:
     - name: Include 'teardown.yml' file

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/setup.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/setup.yml
@@ -1,21 +1,29 @@
 ---
-- name: Create first VPC in eu-central-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_1 }}"
-    name: "{{ test_vpc_name_1_1 }}"
-    region: eu-central-1
-  register: eu_central_1_vpc_1
+- name: Create VPCs in different region
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      aws_security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: Create VPCs from first region
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ item.cidr_block }}"
+        name: "{{ item.name }}"
+        region: "{{ test_vpc_region }}"
+      with_items: "{{ test_vpc_region_1.vpcs }}"
+      register: __vpcs_region1
+      vars:
+        test_vpc_region: "{{ test_vpc_region_1.region }}"
 
-- name: Create second VPC in eu-central-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_2 }}"
-    name: "{{ test_vpc_name_1_2 }}"
-    region: eu-central-1
-  register: eu_central_1_vpc_2
-
-- name: Create VPC in us-west-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_2_1 }}"
-    name: "{{ test_vpc_name_2 }}"
-    region: us-west-1
-  register: us_west_1_vpc_1
+    - name: Create VPCs from second region
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ item.cidr_block }}"
+        name: "{{ item.name }}"
+        region: "{{ test_vpc_region }}"
+      with_items: "{{ test_vpc_region_2.vpcs }}"
+      when: test_vpc_region_2 is defined
+      register: __vpcs_region2
+      vars:
+        test_vpc_region: "{{ test_vpc_region_2.region }}"

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/teardown.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/teardown.yml
@@ -1,27 +1,29 @@
 ---
-- name: Delete first VPC in eu-central-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_1 }}"
-    name: "{{ test_vpc_name_1_1 }}"
-    state: absent
-    region: eu-central-1
-  register: eu_central_1_vpc_1
-  ignore_errors: true
+- name: Delete VPCs
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      aws_security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: Delete VPC from region 1
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ item.cidr_block }}"
+        name: "{{ item.name }}"
+        region: "{{ test_vpc_region }}"
+        state: absent
+      with_items: "{{ test_vpc_region_1.vpcs }}"
+      vars:
+        test_vpc_region: "{{ test_vpc_region_1.region }}"
 
-- name: Delete second VPC in eu-central-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_1_2 }}"
-    name: "{{ test_vpc_name_1_2 }}"
-    state: absent
-    region: eu-central-1
-  register: eu_central_1_vpc_2
-  ignore_errors: true
-
-- name: Delete VPC in us-west-1
-  amazon.aws.ec2_vpc_net:
-    cidr_block: "{{ test_vpc_cidr_2_1 }}"
-    name: "{{ test_vpc_name_2 }}"
-    state: absent
-    region: us-west-1
-  register: us_west_1_vpc_1
-  ignore_errors: true
+    - name: Delete VPC from region 2
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ item.cidr_block }}"
+        name: "{{ item.name }}"
+        region: "{{ test_vpc_region }}"
+        state: absent
+      with_items: "{{ test_vpc_region_2.vpcs }}"
+      when: test_vpc_region_2 is defined
+      vars:
+        test_vpc_region: "{{ test_vpc_region_2.region }}"

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/validate.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/validate.yml
@@ -1,0 +1,21 @@
+---
+- name: Validate that VPC peering exist with status accepted
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      aws_security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: Check VPC peering
+      community.aws.ec2_vpc_peering_info:
+        filters:
+          accepter-vpc-info.vpc-id: "{{ vpc_peering_accepter_vpc_id }}"
+          requester-vpc-info.vpc-id: "{{ vpc_peering_requester_vpc_id }}"
+          status-code: "{{ vpc_peering_status | default('active') }}"
+      register: __vpc_peering
+
+    - name: Validate that VPC peering was found as expected
+      ansible.builtin.assert:
+        that:
+          - __vpc_peering.result | length == 1

--- a/tests/integration/targets/test_manage_vpc_peering/tasks/vpc_peering.yml
+++ b/tests/integration/targets/test_manage_vpc_peering/tasks/vpc_peering.yml
@@ -1,0 +1,63 @@
+---
+# Test: create and accept VPC peering
+- name: Create and accept VPC peering
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    requester_vpc: "{{ vpc_peering_requester_vpc_id }}"
+    accepter_vpc: "{{ vpc_peering_accepter_vpc_id }}"
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_operation: create
+
+- name: Validate that VPC Peering was created and is active
+  ansible.builtin.include_tasks: validate.yml
+
+# Test: delete existing VPC peering
+- name: Delete VPC peering connection request
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_conn_id: "{{ manage_vpc_peering_req_id }}"
+    vpc_peering_operation: delete
+
+- name: Validate that VPC Peering was deleted
+  ansible.builtin.include_tasks: validate.yml
+  vars:
+    vpc_peering_status: "deleted"
+
+# Test: accept existing VPC peering request
+- name: Create VPC peering request
+  community.aws.ec2_vpc_peer:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token | default(omit) }}"
+    region: "{{ aws_region }}"
+    peer_region: "{{ vpc_peering_accepter_region }}"
+    vpc_id: "{{ vpc_peering_requester_vpc_id }}"
+    peer_vpc_id: "{{ vpc_peering_accepter_vpc_id }}"
+    state: present
+  register: __vpc_peering
+
+- name: Set Peering id into variable
+  ansible.builtin.set_fact:
+    vpc_peering_id: "{{ __vpc_peering.peering_id }}"
+
+- name: Create and accept VPC peering
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_conn_id: "{{ vpc_peering_id }}"
+    vpc_peering_operation: accept
+
+- name: Validate that VPC Peering has been accepted
+  ansible.builtin.include_tasks: validate.yml
+
+- name: Delete VPC peering connection
+  ansible.builtin.include_role:
+    name: cloud.aws_ops.manage_vpc_peering
+  vars:
+    region: "{{ vpc_peering_accepter_region }}"
+    vpc_peering_conn_id: "{{ vpc_peering_id }}"
+    vpc_peering_operation: delete


### PR DESCRIPTION
Pull request #44 has been merged while integration tests are not running on the pull request head branch.
The test target is broken, here are some fixes:
- add `aliases` file with `cloud/aws` allowing ansible-test command to provide aws credentials to run tests
- `role/manage_vpc_peering` does not read right credentials variable from aws_setup_credentials role

Some feature have been added
- Test VPC peering statuses: deleted, active