### PR TITLE
Remove pre install from requirements.yml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,13 +83,6 @@ jobs:
           path: ${{ env.source }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Pre install collections dependencies first so the collection install does not
-        run: >-
-          ansible-galaxy collection install
-          --pre "-r${{ env.source }}/tests/integration/requirements.yml"
-          -p /home/runner/collections/
-        shell: bash
-
       - name: Build and install collection
         id: install
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main


### PR DESCRIPTION
amazon.cloud_aws does not have requirements.yml. So removing the related lines from the GHA workflow.