### PR TITLE
Backup role bugfixes

### DIFF
--- a/changelogs/fragments/20230804-backup-role-bugfixes.yaml
+++ b/changelogs/fragments/20230804-backup-role-bugfixes.yaml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - Update README in backup_create_plan role and backup_select_resources role (https://github.com/redhat-cop/cloud.aws_ops/pull/81).
+bugfixes:
+  - Add all necessary IAM service role policies for backup when creating a new IAM role in backup_select_resources role (https://github.com/redhat-cop/cloud.aws_ops/pull/81).

--- a/roles/backup_create_plan/README.md
+++ b/roles/backup_create_plan/README.md
@@ -51,8 +51,10 @@ Example Playbook
     - hosts: localhost
       roles:
         - role: cloud.aws_ops.backup_create_plan
-          plan_name: my-backup-plan
-          plan_rules: "{{ daily_backup }}"
+          vars:
+            plan_name: my-backup-plan
+            plan_rules:
+              - "{{ daily_backup }}"
 
 License
 -------

--- a/roles/backup_select_resources/README.md
+++ b/roles/backup_select_resources/README.md
@@ -13,6 +13,8 @@ AWS User Account with the following permission:
 * backup:GetBackupPlan
 * backup:GetBackupSelection
 * backup:ListBackupSelections
+* iam:AttachRolePolicy
+* iam:CreateRole
 * iam:GetRole
 
 Role Variables

--- a/roles/backup_select_resources/README.md
+++ b/roles/backup_select_resources/README.md
@@ -24,7 +24,7 @@ Role Variables
 * **selection_excluded_resources**: List of resources to exclude from backup
 * **selection_tags**: List of resource tags selected for backup
 * **selection_conditions**: Conditions for resources to back up
-* **backup_role_name**: (Required) The name of an IAM role with permissions to perform all needed backup actions for the selected resources. Alternatively, provide a new for a new IAM role which will be created with the same permissions as the AWSBackupDefaultServiceRole (note: these permissions allow backups and restores for all resources).
+* **backup_role_name**: (Required) The name of an IAM role with permissions to perform all needed backup actions for the selected resources. Alternatively, provide a name for a new IAM role which will be created with the same permissions as the AWSBackupDefaultServiceRole (note: these permissions allow backups and restores for all resources).
 
 ### Included sample resource selection variables
 These are included in vars/main.yaml for use as-is or as examples for modification.
@@ -52,14 +52,17 @@ Example Playbooks
             selection_name: s3_buckets
             selection_resources:
               - "{{ all_s3_buckets }}"
+            backup_role_name: my-iam-role
 
 ### Create backup plan and select resources
 
     - hosts: localhost
       roles:
         - role: cloud.aws_ops.backup_create_plan
-          plan_name: my-backup-plan
-          plan_rules: "{{ daily_backup }}"
+          vars:
+            plan_name: my-backup-plan
+            plan_rules:
+              - "{{ daily_backup }}"
 
     - hosts: localhost
       roles:
@@ -69,6 +72,7 @@ Example Playbooks
             selection_name: s3_buckets
             selection_resources:
               - "{{ all_s3_buckets }}"
+            backup_role_name: my-iam-role
 
 License
 -------

--- a/roles/backup_select_resources/tasks/main.yaml
+++ b/roles/backup_select_resources/tasks/main.yaml
@@ -30,9 +30,9 @@
       register: backup_select_resources_role_info
 
     - name: Create new role when IAM role does not exist
+      when: backup_select_resources_role_info.iam_roles | length == 0
       block:
         - name: Create role
-          when: backup_select_resources_role_info.iam_roles | length == 0
           community.aws.iam_role:
             name: "{{ backup_role_name }}"
             state: present
@@ -41,6 +41,9 @@
             description: "AWS Backup Role"
             managed_policy:
               - arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup
+              - arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores
+              - arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup
+              - arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore
             wait: true
           register: backup_select_resources_new_role_info
 


### PR DESCRIPTION
Fix READMEs in both backup roles, add all needed IAM service role policies when creating a new IAM role in `backup_select_resources` role.