### PR TITLE
Fix Integration tests - collection dependency install

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,8 +53,8 @@ jobs:
     if: ${{ needs.splitter.outputs.test_targets != '' }}
     env:
       source: "./source"
-      ansible_version: "stable-2.14"
-      python_version: "3.9"
+      ansible_version: "milestone"
+      python_version: "3.11"
     strategy:
       fail-fast: false
       matrix:
@@ -83,12 +83,21 @@ jobs:
           path: ${{ env.source }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Pre install collections dependencies first so the collection install does not
+      - name: Set up Python ${{ env.python_version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python_version }}
+
+      # install ansible
+      - name: Install ansible-core (${{ env.ansible_version }})
         run: >-
-          ansible-galaxy collection install
-          --pre "-r${{ env.source }}/tests/integration/requirements.yml"
-          -p /home/runner/collections/
+          python3 -m pip install
+          https://github.com/ansible/ansible/archive/${{ env.ansible_version }}.tar.gz
+          --disable-pip-version-check
         shell: bash
+
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install --pre '-r${{ env.source }}/tests/integration/requirements.yml' -p /home/runner/collections/
 
       - name: Build and install collection
         id: install


### PR DESCRIPTION
The ansible version currently used was not able to install the required collections to run integration, this fix aims to fix that by using `milestone` (which required Python >= 3.9)
This has been successfully validated via PR #101 