### PR TITLE
Fix test failures in deploy_flask_app and backup_select_resources roles

### DIFF
--- a/changelogs/fragments/backup_select_resource_bug_fix.yml
+++ b/changelogs/fragments/backup_select_resource_bug_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix incorrect dict attribute in backup_select_resources role.

--- a/changelogs/fragments/fix_rds_db_version.yml
+++ b/changelogs/fragments/fix_rds_db_version.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Replace the postgres db engine version from 14.8 to 16.2

--- a/playbooks/webapp/README.md
+++ b/playbooks/webapp/README.md
@@ -126,7 +126,7 @@ To delete the webapp:
 * **rds_instance_class** (str): DB instance class for the RDS instance. Default: `db.m6g.large`
 * **rds_instance_name** (str): Name for the database. Default: `mysampledb123`
 * **rds_engine** (str): Engine to use for the database. Default: `postgres`
-* **rds_engine_version** (str): Version number of the database engine to use. Default: `"14.8"`
+* **rds_engine_version** (str): Version number of the database engine to use. Default: `"16.2"`
 * **deploy_flask_app_rds_master_username** (str): Name of the master user for the database instance. Default: `ansible`
 * **deploy_flask_app_rds_master_password** (str): Password for the master database user. Default: `L#5cH2mgy_`
 

--- a/playbooks/webapp/vars/main.yaml
+++ b/playbooks/webapp/vars/main.yaml
@@ -22,7 +22,7 @@ rds_allocated_storage_gb: 20
 rds_instance_class: db.m6g.large
 rds_instance_name: mysampledb123
 rds_engine: postgres
-rds_engine_version: "14.8"
+rds_engine_version: "16.2"
 bastion_host_type: t3.micro
 bastion_host_venv_path: ~/env
 rds_listening_port: 5432

--- a/roles/backup_select_resources/tasks/main.yaml
+++ b/roles/backup_select_resources/tasks/main.yaml
@@ -53,7 +53,7 @@
 
     - name: Set backup role ARN
       ansible.builtin.set_fact:
-        backup_select_resources_backup_role_arn: "{{ backup_select_resources_role_info.iam_roles[0].arn if backup_select_resources_new_role_info is skipped else backup_select_resources_new_role_info.arn }}"
+        backup_select_resources_backup_role_arn: "{{ backup_select_resources_role_info.iam_roles[0].arn if backup_select_resources_new_role_info is skipped else backup_select_resources_new_role_info.iam_role.arn }}"
 
     - name: Create or update backup selection
       amazon.aws.backup_selection:

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
@@ -184,7 +184,7 @@
           - "{{ secgroup.group_id }}"
         user_data: |
           #!/bin/bash
-          yum install -y python3 python-virtualenv sshpass netcat ansible-core
+          yum install -y python3 python3-virtualenv sshpass netcat ansible-core
         wait: true
         state: started
       register: vm_result

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
@@ -184,7 +184,7 @@
           - "{{ secgroup.group_id }}"
         user_data: |
           #!/bin/bash
-          yum install -y python3 python-virtualenv sshpass netcat ansible
+          yum install -y python3 python-virtualenv sshpass netcat ansible-core
         wait: true
         state: started
       register: vm_result

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/vars/main.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/vars/main.yaml
@@ -22,7 +22,7 @@ rds_engine: postgres
 rds_engine_version: "16.2"
 bastion_host_type: t3.micro
 bastion_host_venv_path: ~/env
-image_filter: Fedora-Cloud-Base-38-*
+image_filter: Fedora-Cloud-Base-39-*
 bastion_host_iam_role: "{{ resource_prefix }}-role"
 
 # vars for the deploy_flask_app role and create task

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/vars/main.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/vars/main.yaml
@@ -19,7 +19,7 @@ rds_allocated_storage_gb: 20
 rds_instance_class: db.m6g.large
 rds_instance_name: mysampledb123
 rds_engine: postgres
-rds_engine_version: "14.8"
+rds_engine_version: "16.2"
 bastion_host_type: t3.micro
 bastion_host_venv_path: ~/env
 image_filter: Fedora-Cloud-Base-38-*

--- a/tests/integration/targets/test_deploy_flask_app/runme.sh
+++ b/tests/integration/targets/test_deploy_flask_app/runme.sh
@@ -13,4 +13,4 @@ trap 'cleanup "${@}"'  ERR
 ansible-playbook run.yaml -e "run_deploy_flask_app_operation=create" "$@"
 
 # Delete web application
-ansible-playbook run.yaml -e "run_deploy_flask_app_operation=delete" "$@"
+ ansible-playbook run.yaml -e "run_deploy_flask_app_operation=delete" "$@"


### PR DESCRIPTION
This PR fixes the [integration test failures](https://github.com/redhat-cop/cloud.aws_ops/actions/runs/8802357180/job/24157886634?pr=111) for the following roles

deploy_flask_app:
The Postgres DB engine version 14.8 has been removed and replaced with version 16.2.

backup_select_resources:
Incorrect mention of a dict attribute has been rectified with the right one