### PR TITLE
Update version to point to the next major release in the galaxy.yml file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,7 +21,7 @@ dependencies:
   community.aws: '>=5.0.0'
   amazon.cloud: '>=0.4.0'
   community.libvirt: '>=1.2.0'
-version: 3.0.0-dev0
+version: 4.0.0-dev0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
Since stable-3 has been created, update the galaxy.yml version to 4.0.0-dev0.