### PR TITLE
Update collection to pass tests

### DIFF
--- a/playbooks/webapp/tasks/delete.yaml
+++ b/playbooks/webapp/tasks/delete.yaml
@@ -23,7 +23,7 @@
 
         # Delete Load balancer
         - name: List Load balancer(s) from VPC
-          community.aws.elb_classic_lb_info:
+          amazon.aws.elb_classic_lb_info:
           register: load_balancers
 
         - name: Set fact for list of load balancers to delete

--- a/roles/manage_transit_gateway/tasks/create.yaml
+++ b/roles/manage_transit_gateway/tasks/create.yaml
@@ -2,7 +2,7 @@
 - name: Run create_tgw_attach_vpc role
   block:
     - name: Create  transit gateway
-      community.aws.ec2_transit_gateway:
+      amazon.aws.ec2_transit_gateway:
         state: present
         description: "{{ manage_transit_gateway_transit_gateway.description }}"
         asn: "{{ manage_transit_gateway_transit_gateway.asn }}"

--- a/roles/manage_transit_gateway/tasks/create_vpc_attachment.yaml
+++ b/roles/manage_transit_gateway/tasks/create_vpc_attachment.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Create VPC attachment
-  community.aws.ec2_transit_gateway_vpc_attachment:
+  amazon.aws.ec2_transit_gateway_vpc_attachment:
     state: present
     name: "{{ item.name }}"
     transit_gateway: "{{ manage_transit_gateway_tgw_result.transit_gateway.transit_gateway_id }}"

--- a/roles/manage_transit_gateway/tasks/create_vpn_attachment.yaml
+++ b/roles/manage_transit_gateway/tasks/create_vpn_attachment.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Create vpn connection, with customer gateway and transit_gateway
-  community.aws.ec2_vpc_vpn:
+  amazon.aws.ec2_vpc_vpn:
     customer_gateway_id: '{{ item.customer_gateway_id }}'
     transit_gateway_id: '{{ manage_transit_gateway_tgw_result.transit_gateway.transit_gateway_id }}'
     state: present

--- a/roles/manage_transit_gateway/tasks/delete.yaml
+++ b/roles/manage_transit_gateway/tasks/delete.yaml
@@ -2,7 +2,7 @@
 - name: Run manage_transit_gateway role
   block:
     - name: List all the transit gateway attachments
-      community.aws.ec2_transit_gateway_info:
+      amazon.aws.ec2_transit_gateway_info:
       register: manage_transit_gateway_info
 
     - name: Get the transit gateway with the given description
@@ -17,20 +17,20 @@
       when: manage_transit_gateway_gw is defined
       block:
         - name: Describe attachments on a specific VPC
-          community.aws.ec2_transit_gateway_vpc_attachment_info:
+          amazon.aws.ec2_transit_gateway_vpc_attachment_info:
             filters:
               transit-gateway-id: '{{ manage_transit_gateway_gw.transit_gateway_id }}'
           register: manage_transit_gateway_info
 
         - name: Start deletion of all attachments
-          community.aws.ec2_transit_gateway_vpc_attachment:
+          amazon.aws.ec2_transit_gateway_vpc_attachment:
             state: absent
             id: '{{ item.transit_gateway_attachment_id }}'
             wait: True
           loop: '{{ manage_transit_gateway_info.attachments }}'
 
         - name: Check if all the transit gateway attachments have been deleted
-          community.aws.ec2_transit_gateway_vpc_attachment_info:
+          amazon.aws.ec2_transit_gateway_vpc_attachment_info:
             filters:
               transit-gateway-id: '{{ manage_transit_gateway_gw.transit_gateway_id }}'
           register: manage_transit_gateway_info
@@ -41,7 +41,7 @@
               - manage_transit_gateway_info.attachments | length == 0
 
         - name: Check for vpn attachments
-          community.aws.ec2_vpc_vpn_info:
+          amazon.aws.ec2_vpc_vpn_info:
           register: manage_transit_gateway_vpn_info
 
         - name: Set fact
@@ -53,7 +53,7 @@
           loop: "{{ manage_transit_gateway_vpn_info.vpn_connections }}"
 
         - name: Delete vpn connection, with customer gateway and transit_gateway
-          community.aws.ec2_vpc_vpn:
+          amazon.aws.ec2_vpc_vpn:
             customer_gateway_id: '{{ manage_transit_gateway_cgw }}'
             transit_gateway_id: '{{ manage_transit_gateway_gw.transit_gateway_id }}'
             state: absent
@@ -63,7 +63,7 @@
             - manage_transit_gateway_cgw is defined
 
         - name: Check for vpn attachments after deletion
-          community.aws.ec2_vpc_vpn_info:
+          amazon.aws.ec2_vpc_vpn_info:
           register: manage_transit_gateway_vpn_att_info
 
         - name: Check for vpn attachments
@@ -75,7 +75,7 @@
           loop: "{{ manage_transit_gateway_vpn_att_info.vpn_connections }}"
 
         - name: Delete Transit Gateways
-          community.aws.ec2_transit_gateway:
+          amazon.aws.ec2_transit_gateway:
             state: absent
             transit_gateway_id: '{{ manage_transit_gateway_gw.transit_gateway_id }}'
           ignore_errors: true

--- a/roles/manage_vpc_peering/tasks/accept.yaml
+++ b/roles/manage_vpc_peering/tasks/accept.yaml
@@ -7,7 +7,7 @@
 - name: Accept VPC peering connection request
   block:
     - name: Ensure VPC peering connection request exists before moving forward
-      community.aws.ec2_vpc_peering_info:
+      amazon.aws.ec2_vpc_peering_info:
         peer_connection_ids:
           - "{{ manage_vpc_peering_vpc_peering_conn_id }}"
         region: "{{ manage_vpc_peering_region }}"
@@ -18,7 +18,7 @@
       until: manage_vpc_peering_peering_info.vpc_peering_connections[0].vpc_peering_connection_id is defined
 
     - name: Accept VPC peering request
-      community.aws.ec2_vpc_peer:
+      amazon.aws.ec2_vpc_peering:
         region: "{{ manage_vpc_peering_region }}"
         peering_id: "{{ manage_vpc_peering_vpc_peering_conn_id }}"
         peer_owner_id: "{{ manage_vpc_peering_accepter_vpc_account_id | default(omit) }}"

--- a/roles/manage_vpc_peering/tasks/create.yaml
+++ b/roles/manage_vpc_peering/tasks/create.yaml
@@ -7,7 +7,7 @@
 - name: Create VPC peering
   block:
     - name: Create VPC peering request
-      community.aws.ec2_vpc_peer:
+      amazon.aws.ec2_vpc_peering:
         region: "{{ manage_vpc_peering_region }}"
         peer_region: "{{ manage_vpc_peering_accepter_vpc_region | default(manage_vpc_peering_region, true) }}"
         vpc_id: "{{ manage_vpc_peering_requeter_vpc }}"
@@ -17,7 +17,7 @@
       register: manage_vpc_peering_vpc_peering_request
 
     - name: Ensure VPC peering connection request exists before moving forward
-      community.aws.ec2_vpc_peering_info:
+      amazon.aws.ec2_vpc_peering_info:
         peer_connection_ids:
           - "{{ manage_vpc_peering_vpc_peering_request.peering_id }}"
         region: "{{ manage_vpc_peering_accepter_vpc_region | default(manage_vpc_peering_region, true) }}"
@@ -32,7 +32,7 @@
         seconds: 5
 
     - name: Accept VPC peering request
-      community.aws.ec2_vpc_peer:
+      amazon.aws.ec2_vpc_peering:
         region: "{{ manage_vpc_peering_accepter_vpc_region | default(manage_vpc_peering_region, true) }}"
         peering_id: "{{ manage_vpc_peering_vpc_peering_request.peering_id }}"
         peer_owner_id: "{{ manage_vpc_peering_accepter_vpc_account_id | default(omit) }}"

--- a/roles/manage_vpc_peering/tasks/delete.yaml
+++ b/roles/manage_vpc_peering/tasks/delete.yaml
@@ -7,7 +7,7 @@
 - name: Delete vpc peering connection request
   block:
     - name: Delete a local VPC peering connection
-      community.aws.ec2_vpc_peer:
+      amazon.aws.ec2_vpc_peering:
         region: "{{ manage_vpc_peering_region }}"
         peering_id: "{{ manage_vpc_peering_vpc_peering_conn_id }}"
         state: absent

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,9 @@ commands =
   yamllint -s {toxinidir}
   flake8 {toxinidir}
 
-[testenv:py39-sanity]
+[testenv:sanity]
 deps = ansible
-commands = ansible-test sanity --debug --requirements --local --skip-test future-import-boilerplate --skip-test metaclass-boilerplate --python 3.9
-setenv =
-    HOME = /tmp
+commands = ansible-test sanity
 
 [flake8]
 exclude = .git,.tox,tests/output


### PR DESCRIPTION
This updates the FQCN for several tasks after the modules were migrated from community.aws to amazon.aws. The tox sanity test command has also been updated as it no longer worked on the current version of ansible.