### PR TITLE
Add new ec2_networking_resources role

### DIFF
--- a/roles/ec2_networking_resources/README.md
+++ b/roles/ec2_networking_resources/README.md
@@ -1,0 +1,76 @@
+ec2_networking_resources
+====================
+
+The `ec2_networking_resources` role allows you to create a basic set of networking resources in which you can run EC2 instances. By default, the subnet that is created is set to allow SSH access from within the VPC.
+
+Requirements
+------------
+
+An AWS account with the following permissions:
+
+* ec2:AssociateRouteTable
+* ec2:AuthorizeSecurityGroupIngress
+* ec2:CreateRouteTable
+* ec2:CreateSecurityGroup
+* ec2:CreateSubnet
+* ec2:CreateVpc
+* ec2:DescribeRouteTables
+* ec2:DescribeSecurityGroups
+* ec2:DescribeSubnets
+* ec2:DescribeTags
+* ec2:DescribeVpcAttribute
+* ec2:DescribeVpcs
+* ec2:ModifyVpcAttribute
+* sts:GetCallerIdentity
+
+Role Variables
+--------------
+
+* **ec2_networking_resources_vpc_name**: (Required) The name of the VPC to create.
+* **ec2_networking_resources_vpc_cidr_block**: (Required) The CIDR block to use for the VPC being created.
+* **ec2_networking_resources_subnet_cidr_block**: (Required) The CIDR block to use for subnet being created.
+* **ec2_networking_resources_sg_internal_name**: (Required) The name of the security group to create.
+* **ec2_networking_resources_sg_internal_description**: (Required) The description of the security group being created.
+* **ec2_networking_resources_sg_internal_rules**: (Optional) List of rules to apply to the security group being created. By default, a rule allowing SSH access from within the VPC will be added. A rule should contain the following keys:
+    * **proto** (str): The IP protocol name.
+    * **ports** (str): A list of ports traffic is going to. Can be a single port, or a range of ports, for example, 8000-8010.
+    * **cidr_ip** (str): The CIDR block traffic is coming from.
+
+Dependencies
+------------
+
+- role: [aws_setup_credentials](../aws_setup_credentials/README.md)
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: cloud.aws_ops.ec2_networking_resources
+      vars:
+        ec2_networking_resources_vpc_name: my-vpn
+        ec2_networking_resources_vpc_cidr_block: 10.0.1.0/16
+        ec2_networking_resources_subnet_cidr_block: 10.0.1.0/26
+        ec2_networking_resources_sg_internal_name: my-sg
+        ec2_networking_resources_sg_internal_description: My internal security group
+        ec2_networking_resources_sg_internal_rules:
+          - proto: tcp
+            ports: 22
+            cidr_ip: 10.0.1.0/16
+          - ports: tcp
+            ports: 8000-8010
+            cidr_ip: 10.0.1.0/16
+```
+
+License
+-------
+
+GNU General Public License v3.0 or later
+
+See [LICENSE](../../LICENSE) to see the full text.
+
+Author Information
+------------------
+
+- Ansible Cloud Content Team

--- a/roles/ec2_networking_resources/defaults/main.yml
+++ b/roles/ec2_networking_resources/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+ec2_networking_resources_sg_internal_rules:
+  - proto: tcp
+    ports: 22
+    cidr_ip: "{{ ec2_networking_resources_vpc_cidr_block }}"

--- a/roles/ec2_networking_resources/meta/argument_specs.yml
+++ b/roles/ec2_networking_resources/meta/argument_specs.yml
@@ -31,6 +31,8 @@ argument_specs:
           - A list of security group rules to apply to the security group for internal access.
           - By default, will add a rule to allow SSH access from within the VPC created by the role.
         required: false
+        type: list
+        elements: dict
         default:
           - proto: tcp
             ports: 22

--- a/roles/ec2_networking_resources/meta/argument_specs.yml
+++ b/roles/ec2_networking_resources/meta/argument_specs.yml
@@ -1,0 +1,49 @@
+---
+argument_specs:
+  main:
+    short_description: A role to create a basic networking environment for an EC2 instance.
+    description:
+      - A role to create a basic networking environment for an EC2 instance.
+      - Creates a VPC, subnet, route table and security groups.
+    options:
+      ec2_networking_resources_vpc_name:
+        description:
+          - The name of the VPC to create.
+        required: true
+      ec2_networking_resources_vpc_cidr_block:
+        description:
+          - The CIDR block for the VPC being created.
+        required: true
+      ec2_networking_resources_subnet_cidr_block:
+        description:
+          - The CIDR block for the subnet being created.
+        required: true
+      ec2_networking_resources_sg_internal_name:
+        description:
+          - The name of the security group to create for internal access to the EC2 instance.
+        required: true
+      ec2_networking_resources_sg_internal_description:
+        description:
+          - The description of the security group for internal access to the EC2 instance.
+        required: true
+      ec2_networking_resources_sg_internal_rules:
+        description:
+          - A list of security group rules to apply to the security group for internal access.
+          - By default, will add a rule to allow SSH access from within the VPC created by the role.
+        required: false
+        default:
+          - proto: tcp
+            ports: 22
+            cidr_ip: "{{ ec2_networking_resources_vpc_cidr_block }}"
+        options:
+          proto:
+            description: The IP protocol name.
+            default: tcp
+          ports:
+            description:
+              - A list of ports the traffic is going to.
+              - Elements can be a single port, or a range of ports (for example, 8000-8100).
+            type: list
+            elements: str
+          cidr_ip:
+            description: The CIDR range traffic is coming from.

--- a/roles/ec2_networking_resources/meta/main.yml
+++ b/roles/ec2_networking_resources/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: cloud.aws_ops.aws_setup_credentials

--- a/roles/ec2_networking_resources/tasks/main.yml
+++ b/roles/ec2_networking_resources/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Create VPC
+  amazon.aws.ec2_vpc_net:
+    name: "{{ ec2_networking_resources_vpc_name }}"
+    cidr_block: "{{ ec2_networking_resources_vpc_cidr_block }}"
+  register: ec2_networking_resources_vpc_result
+
+- name: Create VPC subnet
+  amazon.aws.ec2_vpc_subnet:
+    vpc_id: "{{ ec2_networking_resources_vpc_result.vpc.id }}"
+    cidr: "{{ ec2_networking_resources_subnet_cidr_block }}"
+  register: ec2_networking_resources_subnet_result
+
+- name: Create route table
+  amazon.aws.ec2_vpc_route_table:
+    vpc_id: "{{ ec2_networking_resources_vpc_result.vpc.id }}"
+    subnets:
+      - "{{ ec2_networking_resources_subnet_result.subnet.id }}"
+
+- name: Create security group for internal access
+  amazon.aws.ec2_security_group:
+    vpc_id: "{{ ec2_networking_resources_vpc_result.vpc.id }}"
+    name: "{{ ec2_networking_resources_sg_internal_name }}"
+    description: "{{ ec2_networking_resources_sg_internal_description }}"
+    rules: "{{ ec2_networking_resources_sg_internal_rules }}"

--- a/tests/integration/targets/test_ec2_networking_resources/aliases
+++ b/tests/integration/targets/test_ec2_networking_resources/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+role/ec2_networking_resources

--- a/tests/integration/targets/test_ec2_networking_resources/defaults/main.yml
+++ b/tests/integration/targets/test_ec2_networking_resources/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+aws_security_token: "{{ security_token | default(omit) }}"
+
+vpc_name: "{{ resource_prefix }}-vpc"
+vpc_cidr_block: "10.0.1.0/24"
+subnet_cidr_block: "10.0.1.0/26"
+sg_name: "{{ resource_prefix }}-sg"

--- a/tests/integration/targets/test_ec2_networking_resources/tasks/main.yml
+++ b/tests/integration/targets/test_ec2_networking_resources/tasks/main.yml
@@ -1,0 +1,106 @@
+---
+- name: Integration tests for ec2_networking_resources role
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+
+  block:
+    - name: Create networking infrastructure
+      ansible.builtin.include_role:
+        name: cloud.aws_ops.ec2_networking_resources
+      vars:
+        ec2_networking_resources_vpc_name: "{{ vpc_name }}"
+        ec2_networking_resources_vpc_cidr_block: "{{ vpc_cidr_block }}"
+        ec2_networking_resources_subnet_cidr_block: "{{ subnet_cidr_block }}"
+        ec2_networking_resources_sg_internal_name: "{{ sg_name }}"
+        ec2_networking_resources_sg_internal_description: Test security group
+
+    - name: Get the created VPC
+      amazon.aws.ec2_vpc_net_info:
+        filters:
+          "tag:Name": "{{ vpc_name }}"
+          cidr: "{{ vpc_cidr_block }}"
+      register: _vpc
+
+    - name: Assert the VPC exists
+      ansible.builtin.assert:
+        that:
+          - _vpc.vpcs | length == 1
+          - _vpc.vpcs[0].cidr_block == vpc_cidr_block
+
+    - name: Get the created subnet
+      amazon.aws.ec2_vpc_subnet_info:
+        filters:
+          vpc-id: "{{ _vpc.vpcs[0].id }}"
+          cidr-block: "{{ subnet_cidr_block }}"
+      register: _subnet
+
+    - name: Assert subnet has been created
+      ansible.builtin.assert:
+        that:
+          - _subnet.subnets | length == 1
+          - _subnet.subnets[0].cidr_block == subnet_cidr_block
+
+    - name: Get security group
+      amazon.aws.ec2_security_group_info:
+        filters:
+          group-name: "{{ sg_name }}"
+      register: _security_group
+
+    - name: Assert default security group has been created
+      ansible.builtin.assert:
+        that:
+          - _security_group.security_groups | length == 1
+          - _sg_rule.from_port == 22
+          - _sg_rule.to_port == 22
+          - _sg_rule.ip_protocol == "tcp"
+          - _sg_rule.ip_ranges[0].cidr_ip == vpc_cidr_block
+      vars:
+        _sg_rule: "{{ _security_group.security_groups[0].ip_permissions[0] }}"
+
+  always:
+    - name: Delete the security group
+      amazon.aws.ec2_security_group:
+        state: absent
+        name: "{{ sg_name }}"
+      ignore_errors: true
+
+    - name: Get the VPC
+      amazon.aws.ec2_vpc_net_info:
+        filters:
+          "tag:Name": "{{ vpc_name }}"
+          cidr: "{{ vpc_cidr_block }}"
+      register: vpc
+      ignore_errors: true
+
+    - name: Delete the VPC subnet
+      amazon.aws.ec2_vpc_subnet:
+        state: absent
+        vpc_id: "{{ vpc.vpcs[0].id }}"
+        cidr: "{{ subnet_cidr_block }}"
+      ignore_errors: true
+
+    - name: Get the route tables
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          vpc-id: "{{ vpc.vpcs[0].id }}"
+      register: routes
+      ignore_errors: true
+
+    - name: Delete the route tables
+      amazon.aws.ec2_vpc_route_table:
+        state: absent
+        route_table_id: "{{ item.route_table_id }}"
+        lookup: id
+      loop: "{{ routes.route_tables }}"
+      ignore_errors: true
+
+    - name: Delete the VPC
+      amazon.aws.ec2_vpc_net:
+        state: absent
+        name: "{{ vpc_name }}"
+        cidr_block: "{{ vpc_cidr_block }}"
+      ignore_errors: true


### PR DESCRIPTION
This adds a new role to create a basic set of networking resources. This is designed to be used with a role to create an EC2 instance.

See: https://issues.redhat.com/browse/ACA-1958