### PR TITLE
Add security for keypair creation in configure_ec2 pattern

### DIFF
--- a/extensions/patterns/configure_ec2/README.md
+++ b/extensions/patterns/configure_ec2/README.md
@@ -6,7 +6,7 @@ This pattern is designed to help get an EC2 instance up and running.
 
 To enable SSH access to the EC2 instance from your local machine, you need to do 2 things:
 
-1. **Provide a Key Name**: Enter a key name in the **key_name** parameter in the survey. A new key will be created (or an existing key with the specified namewill be used) and associated with the EC2 instance. If creating a new key pair, be sure to save the private key value provided at the end of the job run, as you'll need it for future access to the instance.
+1. **Provide the Key Name**: Specify an existing key name in the **key_name** parameter in the survey. The EC2 instance will be associated with the key pair corresponding to the provided name. If the key pair is unavailable, you will not be able to access the instance from your local machine.
 
 2. **Add a Security Group Rule for SSH Access**: Configure a security group rule to allow inbound SSH traffic from your local machine's IP address. Provide this rule in the **sg_rules** parameter in the survey. Following is an example of the security group rule:
 
@@ -16,6 +16,7 @@ To enable SSH access to the EC2 instance from your local machine, you need to do
     cidr_ip: 203.0.113.0/3
 ```
 
+_Warning_: Please be aware that anyone with access to the job output will be able to view the key.
 
 ## What This Pattern Covers
 

--- a/extensions/patterns/configure_ec2/README.md
+++ b/extensions/patterns/configure_ec2/README.md
@@ -6,9 +6,20 @@ This pattern is designed to help get an EC2 instance up and running.
 
 To enable SSH access to the EC2 instance from your local machine, you need to do 2 things:
 
-1. **Provide a Key Name**: Enter a key name in the **key_name** parameter in the survey. A new key will be created (or an existing key with the specified namewill be used) and associated with the EC2 instance. Be sure to save the private key value provided at the end of the job run, as you'll need it for future access to the instance.
+1. **Provide a Key Name**: Enter a key name in the **key_name** parameter in the survey. A new key will be created (or an existing key with the specified namewill be used) and associated with the EC2 instance. If creating a new key pair, be sure to save the private key value provided at the end of the job run, as you'll need it for future access to the instance.
 
 2. **Add a Security Group Rule for SSH Access**: Configure a security group rule to allow inbound SSH traffic from your local machine's IP address. Provide this rule in the **sg_rules** parameter in the survey.
+
+_Sample Security Group Rule_
+---------------------------
+
+```yaml
+sg_rules:
+  - proto: tcp
+    ports: 22
+    cidr_ip: 203.0.113.0/3
+```
+
 
 ## What This Pattern Covers
 

--- a/extensions/patterns/configure_ec2/README.md
+++ b/extensions/patterns/configure_ec2/README.md
@@ -8,13 +8,9 @@ To enable SSH access to the EC2 instance from your local machine, you need to do
 
 1. **Provide a Key Name**: Enter a key name in the **key_name** parameter in the survey. A new key will be created (or an existing key with the specified namewill be used) and associated with the EC2 instance. If creating a new key pair, be sure to save the private key value provided at the end of the job run, as you'll need it for future access to the instance.
 
-2. **Add a Security Group Rule for SSH Access**: Configure a security group rule to allow inbound SSH traffic from your local machine's IP address. Provide this rule in the **sg_rules** parameter in the survey.
-
-_Sample Security Group Rule_
----------------------------
+2. **Add a Security Group Rule for SSH Access**: Configure a security group rule to allow inbound SSH traffic from your local machine's IP address. Provide this rule in the **sg_rules** parameter in the survey. Following is an example of the security group rule:
 
 ```yaml
-sg_rules:
   - proto: tcp
     ports: 22
     cidr_ip: 203.0.113.0/3

--- a/extensions/patterns/configure_ec2/README.md
+++ b/extensions/patterns/configure_ec2/README.md
@@ -16,8 +16,6 @@ To enable SSH access to the EC2 instance from your local machine, you need to do
     cidr_ip: 203.0.113.0/3
 ```
 
-_Warning_: Please be aware that anyone with access to the job output will be able to view the key.
-
 ## What This Pattern Covers
 
 ### Projects

--- a/extensions/patterns/configure_ec2/README.md
+++ b/extensions/patterns/configure_ec2/README.md
@@ -4,6 +4,12 @@
 
 This pattern is designed to help get an EC2 instance up and running.
 
+To enable SSH access to the EC2 instance from your local machine, you need to do 2 things:
+
+1. **Provide a Key Name**: Enter a key name in the **key_name** parameter in the survey. A new key will be created (or an existing key with the specified namewill be used) and associated with the EC2 instance. Be sure to save the private key value provided at the end of the job run, as you'll need it for future access to the instance.
+
+2. **Add a Security Group Rule for SSH Access**: Configure a security group rule to allow inbound SSH traffic from your local machine's IP address. Provide this rule in the **sg_rules** parameter in the survey.
+
 ## What This Pattern Covers
 
 ### Projects

--- a/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
@@ -14,10 +14,19 @@
       ansible.builtin.set_fact:
         final_sg_rules: "{{ create_external_access_resources | ternary(sg_rules_list + allow_external_access_sg_rules, sg_rules_list) }}"
 
-    - name: Set manage_ec2_instance_key_name role var
-      ansible.builtin.set_fact:
-        manage_ec2_instance_key_name: "{{ key_name }}"
+    - name: Validate key "{{ key_name }}" if given
       when: key_name is defined and key_name != ''
+      block:
+      - name: Check if the key "{{ key_name }}" exists
+        amazon.aws.ec2_key_info:
+          names:
+            - "{{ key_name }}"
+        register: key_info_result
+
+      - name: Set manage_ec2_instance_key_name role var
+        ansible.builtin.set_fact:
+          manage_ec2_instance_key_name: "{{ key_name }}"
+        when: key_info_result.keypairs | length > 0
 
     - name: Get RHEL 9 AMI ID if needed
       when: ami_id | default("", true) == ""
@@ -30,6 +39,7 @@
             owner:
               - amazon
           register: images
+
         - name: Update ami_id variable
           ansible.builtin.set_fact:
             ami_id: "{{ (images.images | sort(attribute='name') | last).image_id }}"
@@ -61,7 +71,7 @@
         manage_ec2_instance_associate_eip: "{{ create_external_access_resources }}"
         manage_ec2_instance_instance_tags: "{{ instance_tags | default('{}', true) | from_json }}"
 
-    - name: Output private key if a new keypair was created
-      when: ec2_instance_manage_key_pair_result.key is defined
+    - name: Warn if key "{{ key_name }} does not exist
       ansible.builtin.debug:
-        msg: "A new key pair was created for ssh access to the instance. Please save this private key for reference: {{ ec2_instance_manage_key_pair_result.key.private_key }}"
+        msg: "Warning: The key '{{ key_name }}' does not exist!"
+      when: key_name is defined and key_info_result.keypairs | length == 0

--- a/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
@@ -14,6 +14,11 @@
       ansible.builtin.set_fact:
         final_sg_rules: "{{ create_external_access_resources | ternary(sg_rules_list + allow_external_access_sg_rules, sg_rules_list) }}"
 
+    - name: Set manage_ec2_instance_key_name role var
+      ansible.builtin.set_fact:
+        manage_ec2_instance_key_name: "{{ key_name }}"
+      when: key_name is defined
+
     - name: Get RHEL 9 AMI ID if needed
       when: ami_id | default("", true) == ""
       block:
@@ -28,7 +33,7 @@
         - name: Update ami_id variable
           ansible.builtin.set_fact:
             ami_id: "{{ (images.images | sort(attribute='name') | last).image_id }}"
-
+    
     - name: Create networking resources
       ansible.builtin.include_role:
         name: cloud.aws_ops.ec2_networking_resources
@@ -50,9 +55,13 @@
         manage_ec2_instance_instance_name: "{{ instance_name }}"
         manage_ec2_instance_instance_type: "{{ instance_type }}"
         manage_ec2_instance_ami_id: "{{ ami_id }}"
-        manage_ec2_instance_key_name: "{{ key_name }}"
         manage_ec2_instance_vpc_subnet_id: "{{ ec2_networking_resources_subnet_result.subnet.id }}"
         manage_ec2_instance_wait_for_state: "{{ wait_for_state | bool }}"
         manage_ec2_instance_associate_security_groups: "{{ [sg_name] }}"
         manage_ec2_instance_associate_eip: "{{ create_external_access_resources }}"
         manage_ec2_instance_instance_tags: "{{ instance_tags | default('{}', true) | from_json }}"
+
+    - name: Output private key if a new keypair was created
+      when: ec2_instance_manage_key_pair_result.key is defined
+      ansible.builtin.debug:
+        msg: "A new key pair was created for ssh access to the instance. Please save this private key for reference: {{ ec2_instance_manage_key_pair_result.key.private_key }}"

--- a/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
@@ -14,10 +14,10 @@
       ansible.builtin.set_fact:
         final_sg_rules: "{{ create_external_access_resources | ternary(sg_rules_list + allow_external_access_sg_rules, sg_rules_list) }}"
 
-    - name: Validate key "{{ key_name }}" if given
+    - name: Validate key if given
       when: key_name is defined and key_name != ''
       block:
-        - name: Check if the key "{{ key_name }}" exists
+        - name: Check if the key exists
           amazon.aws.ec2_key_info:
             names:
               - "{{ key_name }}"
@@ -71,7 +71,7 @@
         manage_ec2_instance_associate_eip: "{{ create_external_access_resources }}"
         manage_ec2_instance_instance_tags: "{{ instance_tags | default('{}', true) | from_json }}"
 
-    - name: Warn if key "{{ key_name }} does not exist
+    - name: Warn if key does not exist
       ansible.builtin.debug:
         msg: "Warning: The key '{{ key_name }}' does not exist!"
       when: key_name is defined and key_info_result.keypairs | length == 0

--- a/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
@@ -17,7 +17,7 @@
     - name: Set manage_ec2_instance_key_name role var
       ansible.builtin.set_fact:
         manage_ec2_instance_key_name: "{{ key_name }}"
-      when: key_name is defined
+      when: key_name is defined and key_name != ''
 
     - name: Get RHEL 9 AMI ID if needed
       when: ami_id | default("", true) == ""
@@ -33,7 +33,7 @@
         - name: Update ami_id variable
           ansible.builtin.set_fact:
             ami_id: "{{ (images.images | sort(attribute='name') | last).image_id }}"
-    
+
     - name: Create networking resources
       ansible.builtin.include_role:
         name: cloud.aws_ops.ec2_networking_resources

--- a/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
@@ -17,16 +17,16 @@
     - name: Validate key "{{ key_name }}" if given
       when: key_name is defined and key_name != ''
       block:
-      - name: Check if the key "{{ key_name }}" exists
-        amazon.aws.ec2_key_info:
-          names:
-            - "{{ key_name }}"
-        register: key_info_result
+        - name: Check if the key "{{ key_name }}" exists
+          amazon.aws.ec2_key_info:
+            names:
+              - "{{ key_name }}"
+          register: key_info_result
 
-      - name: Set manage_ec2_instance_key_name role var
-        ansible.builtin.set_fact:
-          manage_ec2_instance_key_name: "{{ key_name }}"
-        when: key_info_result.keypairs | length > 0
+        - name: Set manage_ec2_instance_key_name role var
+          ansible.builtin.set_fact:
+            manage_ec2_instance_key_name: "{{ key_name }}"
+          when: key_info_result.keypairs | length > 0
 
     - name: Get RHEL 9 AMI ID if needed
       when: ami_id | default("", true) == ""

--- a/extensions/patterns/configure_ec2/playbooks/group_vars/all.yml
+++ b/extensions/patterns/configure_ec2/playbooks/group_vars/all.yml
@@ -1,4 +1,3 @@
-key_name: "{{ instance_name }}-key"
 wait_for_state: true
 vpc_name: "{{ instance_name }}-vpc"
 vpc_cidr: 10.0.0.0/24

--- a/extensions/patterns/configure_ec2/template_surveys/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/template_surveys/create_ec2_instance.yml
@@ -28,7 +28,7 @@ spec:
 
   - type: text
     question_name: Key Pair Name
-    question_description: Name of key pair to use or create for SSH access to the EC2 instance. Defaults to '{{ instance_name }}-key'
+    question_description: Name of key pair to use or create for SSH access to the EC2 instance. If the key does not exist, a key pair will be created with the name. If not provided, instance will not be accessible via SSH.
     variable: key_name
     required: false
 

--- a/extensions/patterns/configure_ec2/template_surveys/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/template_surveys/create_ec2_instance.yml
@@ -28,7 +28,7 @@ spec:
 
   - type: text
     question_name: Key Pair Name
-    question_description: Name of key pair to use or create for SSH access to the EC2 instance. If the key does not exist, a key pair will be created with the name. If not provided, instance will not be accessible via SSH.
+    question_description: Name of key pair to use for SSH access to the EC2 instance. If the key does not exist or not provided, the instance will not be accessible via SSH.
     variable: key_name
     required: false
 

--- a/roles/manage_ec2_instance/README.md
+++ b/roles/manage_ec2_instance/README.md
@@ -6,7 +6,7 @@ Users can specify various parameters for instance configuration, including insta
 
 This role can be combined with the [cloud.aws_ops.ec2_networking_resources role](../ec2_networking_resources/README.md) to create/delete networking resources for the instance, see [examples](#examples).
 
-EC2 instance details and the private key (if a key pair is created) will be displayed as role output. The instance and key pair details are accessible via variables `ec2_instance_manage_create_result` and `ec2_instance_manage_key_pair_result`, respectively.
+The instance and key pair details are accessible via variables `ec2_instance_manage_create_result` and `ec2_instance_manage_key_pair_result`, respectively.
 
 ## Requirements
 

--- a/roles/manage_ec2_instance/tasks/ec2_instance_create_operations.yml
+++ b/roles/manage_ec2_instance/tasks/ec2_instance_create_operations.yml
@@ -21,6 +21,7 @@
         names:
           - "{{ manage_ec2_instance_key_name }}"
       register: key_info_result
+      no_log: true
 
     - name: Create new key pair
       amazon.aws.ec2_key:
@@ -28,6 +29,7 @@
         state: present
       when: key_info_result.keypairs | length == 0
       register: ec2_instance_manage_key_pair_result
+      no_log: true
 
 - name: Create EC2 instance with provided configuration
   amazon.aws.ec2_instance:

--- a/roles/manage_ec2_instance/tasks/ec2_instance_create_operations.yml
+++ b/roles/manage_ec2_instance/tasks/ec2_instance_create_operations.yml
@@ -61,8 +61,3 @@
     msg:
       - "EC2 instance {{ ec2_instance.instance_ids[0] }} created successfully"
       - "Instance details: {{ ec2_instance_manage_create_result.instances[0] }}"
-
-- name: Output private key if a new keypair was created
-  when: ec2_instance_manage_key_pair_result.key is defined
-  ansible.builtin.debug:
-    msg: "A new key pair was created for ssh access to the instance. Please save this private key for reference: {{ ec2_instance_manage_key_pair_result.key.private_key }}"


### PR DESCRIPTION
Refer : https://issues.redhat.com/browse/ACA-2059
This PR  ensures that private keys to ec2 instances are not available in job logs by default