### PR TITLE
Small updates to ec2 pattern

### DIFF
--- a/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/playbooks/create_ec2_instance.yml
@@ -21,12 +21,12 @@
           amazon.aws.ec2_key_info:
             names:
               - "{{ key_name }}"
-          register: key_info_result
+          register: pattern_key_info_result
 
         - name: Set manage_ec2_instance_key_name role var
           ansible.builtin.set_fact:
             manage_ec2_instance_key_name: "{{ key_name }}"
-          when: key_info_result.keypairs | length > 0
+          when: pattern_key_info_result.keypairs | length > 0
 
     - name: Get RHEL 9 AMI ID if needed
       when: ami_id | default("", true) == ""
@@ -73,5 +73,5 @@
 
     - name: Warn if key does not exist
       ansible.builtin.debug:
-        msg: "Warning: The key '{{ key_name }}' does not exist!"
-      when: key_name is defined and key_info_result.keypairs | length == 0
+        msg: "Warning: The provided key '{{ key_name }}' does not exist!"
+      when: key_name is defined and pattern_key_info_result.keypairs | length == 0

--- a/extensions/patterns/configure_ec2/template_surveys/terminate_ec2_instance.yml
+++ b/extensions/patterns/configure_ec2/template_surveys/terminate_ec2_instance.yml
@@ -16,7 +16,7 @@ spec:
 
   - type: text
     question_name: Key Pair Name
-    question_description: Name of key pair for instance, include to delete key pair created with other instance resources. Defaults to '{{ instance_name }}-key'
+    question_description: Name of key pair for instance, include to delete key pair created with other instance resources.
     variable: key_name
     required: false
 

--- a/roles/manage_ec2_instance/tasks/ec2_instance_create_operations.yml
+++ b/roles/manage_ec2_instance/tasks/ec2_instance_create_operations.yml
@@ -21,7 +21,6 @@
         names:
           - "{{ manage_ec2_instance_key_name }}"
       register: key_info_result
-      no_log: true
 
     - name: Create new key pair
       amazon.aws.ec2_key:


### PR DESCRIPTION
Two updates:
- We can't use the var `key_info_result` in the pattern playbook, because it gets overwritten by the included role playbook.
- It's ok to log the `ec2_key_info` output because that doesn't include the private key, and if there's an error with the key (for example if the user was expecting the key to be present) it's helpful to be able to see what the returned value was.