### PR TITLE
Update container image registry: docker.io -> quay.io

### DIFF
--- a/changelogs/fragments/20250116-move-ee-from-dockerhub-to-quay.yaml
+++ b/changelogs/fragments/20250116-move-ee-from-dockerhub-to-quay.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Move EE use for configure_ec2 pattern from DockerHub to quay.io (https://github.com/redhat-cop/cloud.aws_ops/pull/131).

--- a/extensions/patterns/configure_ec2/exec_env/execution-environment.yml
+++ b/extensions/patterns/configure_ec2/exec_env/execution-environment.yml
@@ -22,7 +22,7 @@ dependencies:
 
 images:
   base_image:
-    name: registry.redhat.io/ubi9/ubi:latest
+    name: registry.access.redhat.com/ubi9/ubi:latest
 
 additional_build_steps:
   append_base: |

--- a/extensions/patterns/configure_ec2/exec_env/execution-environment.yml
+++ b/extensions/patterns/configure_ec2/exec_env/execution-environment.yml
@@ -22,8 +22,8 @@ dependencies:
 
 images:
   base_image:
-    name: quay.io/centos/centos:stream9
+    name: registry.redhat.io/ubi9/ubi:latest
 
 additional_build_steps:
   append_base: |
-    RUN yum install -y git python3.11
+    RUN yum install -y git

--- a/extensions/patterns/configure_ec2/exec_env/execution-environment.yml
+++ b/extensions/patterns/configure_ec2/exec_env/execution-environment.yml
@@ -22,8 +22,8 @@ dependencies:
 
 images:
   base_image:
-    name: docker.io/redhat/ubi9:latest
+    name: quay.io/centos/centos:stream9
 
 additional_build_steps:
   append_base: |
-    RUN yum install -y git
+    RUN yum install -y git python3.11

--- a/extensions/patterns/configure_ec2/setup.yml
+++ b/extensions/patterns/configure_ec2/setup.yml
@@ -57,5 +57,5 @@ controller_templates:
 controller_execution_environments:
   - name: AWS Operations / Configure EC2 Instance Pattern Execution Environment
     description: Execution environment for the Configure EC2 Instance Pattern
-    image: docker.io/hakbailey/aws_ops-ee:latest
+    image: quay.io/abikouo1/ee/cloud-awsops:latest
     pull: always


### PR DESCRIPTION
Ensure configure_ec2 pattern EE does not use DockerHub to pull or host images
The container image has been moved from DockerHub to quay.io