### PR TITLE
roles/ec2_networking_resources - add ``version_added``

### DIFF
--- a/changelogs/fragments/2024-12-04_ec2_networking_role_add_options.yml
+++ b/changelogs/fragments/2024-12-04_ec2_networking_role_add_options.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- ec2_networking_resources - Add optional networking resources and ability to delete resources created by role. (https://github.com/redhat-cop/cloud.aws_ops/pull/126)

--- a/changelogs/fragments/20250116-move-ee-from-dockerhub-to-quay.yaml
+++ b/changelogs/fragments/20250116-move-ee-from-dockerhub-to-quay.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Move EE use for configure_ec2 pattern from DockerHub to quay.io (https://github.com/redhat-cop/cloud.aws_ops/pull/131).

--- a/roles/ec2_networking_resources/meta/argument_specs.yml
+++ b/roles/ec2_networking_resources/meta/argument_specs.yml
@@ -1,6 +1,7 @@
 ---
 argument_specs:
   main:
+    version_added: 3.1.0
     short_description: A role to create a basic networking environment for an EC2 instance.
     description:
       - A role to create a basic networking environment for an EC2 instance.


### PR DESCRIPTION
This pull request contains the following changes:
- add ``version_added`` to role ``ec2_networking_resources``for the role to be listed in the release changelog
- The role ``ec2_networking_resources`` and the ec2 pattern have not yet been released, we must remove the changelog file describing changes on these new features.