### PR TITLE
CI - fix ansible-lint issues

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -8,4 +8,5 @@ skip_list:
   - no-handler  # Tasks that run when changed should likely be handlers.
   - no-changed-when  # Commands should not change things if nothing needs doing.
 exclude_paths:
+  - .ansible/
   - tests/integration

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
 
       - name: run-ansible-lint
-        uses: ansible/ansible-lint@v24.7.0
+        uses: ansible/ansible-lint@v24.12.2

--- a/changelogs/fragments/20250127-fix-ansible-lint.yaml
+++ b/changelogs/fragments/20250127-fix-ansible-lint.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - update FQCN for modules that were migrated from community.aws to amazon.aws (https://github.com/redhat-cop/cloud.aws_ops/pull/152).

--- a/changelogs/fragments/20250127-fix-ansible-lint.yaml
+++ b/changelogs/fragments/20250127-fix-ansible-lint.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - update FQCN for modules that were migrated from community.aws to amazon.aws (https://github.com/redhat-cop/cloud.aws_ops/pull/152).


### PR DESCRIPTION
Fixing CI issue from Release PR https://github.com/redhat-cop/cloud.aws_ops/pull/150
Update to ansible-lint `24.12.2` to fix ansible-lint. The previous version does not ignore the directory `test/integration`
See https://github.com/redhat-cop/cloud.aws_ops/actions/runs/12993916513/job/36237187718?pr=150