### PR TITLE
Add new workflow to label prs with needs_triage

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -1,0 +1,28 @@
+---
+name: label new prs
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - converted_to_draft
+      - ready_for_review
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add 'needs_triage' label if the pr is not a draft
+        uses: actions-ecosystem/action-add-labels@v1
+        if: github.event.pull_request.draft == false
+        with:
+          labels: needs_triage
+
+      - name: Remove 'needs_triage' label if the pr is a draft
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: github.event.pull_request.draft == true
+        with:
+          labels: needs_triage
+

--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -1,7 +1,7 @@
 ---
 name: label new prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -25,4 +25,3 @@ jobs:
         if: github.event.pull_request.draft == true
         with:
           labels: needs_triage
-


### PR DESCRIPTION
SUMMARY

This pr adds a new workflow for labeling new and reopened prs that are not marked as draft. The needs_triage label will be removed if the pr is marked as draft during development and re-added once the pr is marked as ready for review.

After consulting with the team, we decided to label prs in a new workflow to allow for the prs and issues to have different labels in the future.

[ACA-2362](https://issues.redhat.com/browse/ACA-2362)

#### Reported CI Issues
Sanity tests: https://github.com/redhat-cop/cloud.aws_ops/issues/173 
