### PR TITLE
[PR #180/60fb1b78 backport][stable-3] update integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,6 @@
 name: Integration
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -12,119 +12,75 @@ on:
       - stable-*
 
 jobs:
-  safe-to-test:
-    if: ${{ github.event.label.name == 'safe to test' }} || ${{ github.event.action != 'labeled' }}
-    uses: ansible-network/github_actions/.github/workflows/safe-to-test.yml@main
   splitter:
-    needs:
-      - safe-to-test
     runs-on: ubuntu-latest
     env:
       source_dir: "cloud_awsops"
     outputs:
-      test_targets: ${{ steps.splitter.outputs.test_targets }}
-      test_targets_json: ${{ steps.splitter.outputs.test_targets_json }}
-      test_jobs: ${{ steps.splitter.outputs.test_jobs }}
+      targets: ${{ steps.splitter.outputs.targets }}
+      test_jobs: ${{ steps.splitter.outputs.jobs }}
     steps:
       - name: Checkout collection
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: ${{ env.source_dir }}
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: "0"
 
       - name: List changes for pull request
         id: splitter
-        uses: ansible-network/github_actions/.github/actions/ansible_test_splitter@main
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_test_splitter@a93c78e1d842d4ee8961769110d88ac16bcc217a  # main, Commits on May 15, 2026
         with:
           collections_to_test: ${{ env.source_dir }}
           total_jobs: 2
+          base_ref: "${{ github.event.pull_request.base.ref }}"
 
       - name: Display splitter output
         run: |
-          echo "test_targets=${{ steps.splitter.outputs.test_targets }}"
-          echo "test_targets_json=${{ steps.splitter.outputs.test_targets_json }}"
-          echo "test_jobs=${{ steps.splitter.outputs.test_jobs }}"
+          echo "test_targets=${{ steps.splitter.outputs.targets }}"
+          echo "test_jobs=${{ steps.splitter.outputs.jobs }}"
         shell: bash
-  test:
+  integration_tests:
     runs-on: ubuntu-latest
     needs:
       - splitter
-    if: ${{ needs.splitter.outputs.test_targets != '' }}
+    if: ${{ needs.splitter.outputs.targets != '' }}
+    # environment: protected  # requires manual approval within GitHub Actions to proceed
     env:
       source: "./source"
       ansible_version: "milestone"
-      python_version: "3.11"
+      python_version: "3.12"
+      ansible_test_splitter_targets: "${{ needs.splitter.outputs.targets }}"
     strategy:
       fail-fast: false
       matrix:
         workflow-id: ${{ fromJson(needs.splitter.outputs.test_jobs) }}
     name: "integration-${{ matrix.workflow-id }}"
     steps:
-      - name: Read target
+      - name: Read job targets
         id: read-targets
-        run: |
-          import json, os
-          with open(os.environ.get('GITHUB_OUTPUT'), "a", encoding="utf-8") as fh:
-              fh.write(f'ansible_test_targets={json.loads(os.environ.get("ALL_TEST_TARGETS")).get(os.environ.get("WORKFLOW_ID"))}\n')
-        shell: python
-        env:
-          ALL_TEST_TARGETS: ${{ needs.splitter.outputs.test_targets_json }}
-          WORKFLOW_ID: ${{ matrix.workflow-id }}
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_read_targets@0b891487c4170ef856f02313c66cb1c776814c42  # main, committedon Apr 1, 2026
+        with:
+          job_id: "${{ matrix.workflow-id }}"
+          all_targets: "${{ env.ansible_test_splitter_targets }}"
 
       - name: Display ansible test targets
         run: |
-          echo "ansible_test_targets -> ${{ steps.read-targets.outputs.ansible_test_targets }}"
+          echo "ansible_test_targets -> ${{ steps.read-targets.outputs.job_targets }}"
         shell: bash
-
-      - name: Checkout collection
-        uses: actions/checkout@v3
-        with:
-          path: ${{ env.source }}
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Set up Python ${{ env.python_version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.python_version }}
-
-      # install ansible
-      - name: Install ansible-core (${{ env.ansible_version }})
-        run: >-
-          python3 -m pip install
-          https://github.com/ansible/ansible/archive/${{ env.ansible_version }}.tar.gz
-          --disable-pip-version-check
-        shell: bash
-
-      - name: Pre install collections dependencies first so the collection install does not
-        run: ansible-galaxy collection install --pre '-r${{ env.source }}/tests/integration/requirements.yml' -p /home/runner/collections/
-
-      - name: Build and install collection
-        id: install
-        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
-        with:
-          install_python_dependencies: false
-          source_path: ${{ env.source }}
 
       - name: Create AWS/sts session credentials
-        uses: ansible-network/github_actions/.github/actions/ansible_aws_test_provider@main
-        with:
-          collection_path: ${{ steps.install.outputs.collection_path }}
-          ansible_core_ci_key: ${{ secrets.ANSIBLE_CORE_CI_KEY }}
-
-      # we use raw git to create a repository in the tests
-      # this fails if the committer doesn't have a name and an email set
-      - name: Set up git
-        run: |
-          git config --global user.email gha@localhost
-          git config --global user.name "Github Actions"
-        shell: bash
+        uses: ansible/ansible-test-auth@008750a5bf07124c3ab86d30d73d7319d7518f36  # v1.0.0, committed on Mar 13, 2026
 
       - name: Run integration tests
-        uses: ansible-network/github_actions/.github/actions/ansible_test_integration@main
+        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e  # v1.17.0, committed on Aug 6, 2025
         with:
-          collection_path: ${{ steps.install.outputs.collection_path }}
-          python_version: ${{ env.python_version }}
-          ansible_version: ${{ env.ansible_version }}
-          ansible_test_requirement_files: 'test-requirements.txt'
-          ansible_test_targets: ${{ steps.read-targets.outputs.ansible_test_targets }}
+          ansible-core-version: ${{ env.ansible_version }}
+          origin-python-version: ${{ env.python_version }}
+          testing-type: integration
+          target-python-version: ${{ env.python_version }}
+          target: ${{ steps.read-targets.outputs.job_targets }}
+          test-deps: >-
+            git+https://github.com/ansible-collections/amazon.aws.git,main
+            git+https://github.com/ansible-collections/community.aws.git,main
+            community.crypto
+          pre-test-cmd: python -m pip install -r tests/integration/constraints.txt -r tests/integration/requirements.txt

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.22.0
-botocore==1.25.0
+boto3==1.38.23
+botocore==1.38.23
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.23.0
+awscli==1.40.22

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,5 @@
 # Our code is based on the AWS SDKs
 boto3
 botocore
+
+awscli


### PR DESCRIPTION
This is a backport of PR https://github.com/redhat-cop/cloud.aws_ops/pull/180 as merged into main (https://github.com/redhat-cop/cloud.aws_ops/commit/60fb1b78fc8f15d093d0418386e28d4132494c77).

Depends-ON: 
https://github.com/ansible/cloud-content-ci-automation/pull/7,
This PR updates the integration tests workflow with the following changes.
https://github.com/redhat-cop/cloud.aws_ops/pull/185,
This PR will fix linter issues and remove support for ansible-core < 2.17.

Migrate to the centralized version of the ansible_test_splitter action
Use the dedicated GHA to generate AWS credentials for testing and remove the use of secret ANSIBLE_CORE_CI_KEY
Update trigger from pull_request_target to pull_request since we no longer need access to secrets
Use ansible-community/ansible-test-gh-action GHA to run integration tests.

Reported CI Issues
Integration tests https://github.com/redhat-cop/cloud.aws_ops/issues/184