### PR TITLE
[ACA-5132] ci: add Galaxy importer workflow for PR validation

### DIFF
--- a/.github/workflows/galaxy-importer.yaml
+++ b/.github/workflows/galaxy-importer.yaml
@@ -1,0 +1,15 @@
+name: Galaxy Importer
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+      - stable-*
+
+jobs:
+  galaxy-import:
+    uses: ansible-network/github_actions/.github/workflows/galaxy_importer.yml@4eb390a8c86b0c1eae9a87624a117193839579ef  # main, authored on May 5, 2023


### PR DESCRIPTION
SUMMARY
Adds a new GitHub Actions workflow that validates collection metadata and structure using the Galaxy importer on every pull request. This ensures the collection can be successfully imported to Ansible Galaxy before merging changes.

The workflow uses the reusable galaxy_importer.yml workflow from ansible-network/github_actions and runs on PRs targeting main and stable-* branches.

ISSUE TYPE
Feature Pull Request
COMPONENT NAME
galaxy-import workflow

ADDITIONAL INFORMATION
Workflow uses concurrency groups to cancel in-progress runs when new commits are pushed
Validates collection structure, metadata, and documentation
No changelog fragment needed (CI infrastructure change)
Assisted-by: Claude Sonnet 4.5