### PR TITLE
[PR #190/e8f35dc manually backport][stable-4] ci: update integration and coverage workflow python version

### DIFF
--- a/.github/workflows/coverage_test.yml
+++ b/.github/workflows/coverage_test.yml
@@ -6,10 +6,6 @@ concurrency:
   cancel-in-progress: true
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    branches:
-      - main
-      - stable-*
   push:
     branches:
       - main
@@ -22,9 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ANSIBLE_CORE_REF: "milestone"
+      PYTHON_VERSION: "3.13"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # ansible-test requires cwd under .../ansible_collections/{namespace}/{name}/
           path: ansible_collections/cloud/aws_ops
@@ -50,32 +47,40 @@ jobs:
           path: ansible_collections/community/crypto
           ref: main
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Checkout community.general dependency
+        uses: ansible-network/github_actions/.github/actions/checkout_dependency@47822b51aee957080e811cc434443c4e3bb9569a
         with:
-          python-version: "3.12"
+          repository: ansible-collections/community.general
+          path: ansible_collections/community/general
+          ref: main
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # actions/setup-python already provides a recent pip; do not run an unpinned
+      # "pip install --upgrade pip" (githubactions:S8544).
       - name: Install Ansible (ansible-test)
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_CORE_REF}.tar.gz"
+        # Floating ansible-core milestone/devel is intentional for coverage CI.
+        # Not a PyPI pin — suppress S8544 for this line only.
+        run: python -m pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_CORE_REF}.tar.gz"  # NOSONAR
 
       - name: Install integration test dependencies
-        run: |
-          python -m pip install -r ansible_collections/cloud/aws_ops/tests/integration/constraints.txt -r ansible_collections/cloud/aws_ops/tests/integration/requirements.txt
+        run: python -m pip install -r ansible_collections/cloud/aws_ops/tests/integration/constraints.txt -r ansible_collections/cloud/aws_ops/tests/integration/requirements.txt  # NOSONAR
 
       - name: Create AWS/sts session credentials
         uses: ansible/ansible-test-auth@008750a5bf07124c3ab86d30d73d7319d7518f36  # v1.0.0, committed on Mar 13, 2026
 
       - name: Run integration tests with coverage
         working-directory: ansible_collections/cloud/aws_ops
-        run: ansible-test integration --venv --coverage --python 3.12 --requirements
+        run: ansible-test integration --venv --coverage --python ${{ env.PYTHON_VERSION }} --requirements
 
       - name: Combine and emit coverage XML
         working-directory: ansible_collections/cloud/aws_ops
         run: |
-          ansible-test coverage combine --venv --python 3.12 --requirements
-          ansible-test coverage xml --venv --python 3.12 --requirements
+          ansible-test coverage combine --venv --python ${{ env.PYTHON_VERSION }} --requirements
+          ansible-test coverage xml --venv --python ${{ env.PYTHON_VERSION }} --requirements
 
       - name: Prepare coverage.xml for SonarCloud
         env:
@@ -97,7 +102,7 @@ jobs:
           test -s "${GITHUB_WORKSPACE}/coverage.xml"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1 authored on Apr 10, 2026
         with:
           name: coverage
           path: ${{ github.workspace }}/coverage.xml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
       test_jobs: ${{ steps.splitter.outputs.jobs }}
     steps:
       - name: Checkout collection
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           path: ${{ env.source_dir }}
           fetch-depth: "0"
@@ -31,7 +31,7 @@ jobs:
         uses: ansible/cloud-content-ci-automation/.github/actions/ansible_test_splitter@a93c78e1d842d4ee8961769110d88ac16bcc217a  # main, Commits on May 15, 2026
         with:
           collections_to_test: ${{ env.source_dir }}
-          total_jobs: 2
+          total_jobs: 8
           base_ref: "${{ github.event.pull_request.base.ref }}"
 
       - name: Display splitter output
@@ -48,7 +48,7 @@ jobs:
     env:
       source: "./source"
       ansible_version: "milestone"
-      python_version: "3.12"
+      python_version: "3.13"
       ansible_test_splitter_targets: "${{ needs.splitter.outputs.targets }}"
     strategy:
       fail-fast: false
@@ -83,4 +83,6 @@ jobs:
             git+https://github.com/ansible-collections/amazon.aws.git,main
             git+https://github.com/ansible-collections/community.aws.git,main
             community.crypto
+            community.general
           pre-test-cmd: python -m pip install -r tests/integration/constraints.txt -r tests/integration/requirements.txt
+          coverage: never

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -38,6 +38,14 @@ jobs:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.11"
+            },
+            {
               "ansible-version": "stable-2.19",
               "python-version": "3.10"
             },
@@ -50,8 +58,16 @@ jobs:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.14"
+            },
+            {
               "ansible-version": "stable-2.17",
               "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.14"
             },
             {
               "ansible-version": "stable-2.16"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -22,6 +22,10 @@ jobs:
               "python-version": "3.11"
             },
             {
+              "ansible-version": "devel",
+              "python-version": "3.12"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.11"
             },
@@ -38,6 +42,10 @@ jobs:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.19",
+              "python-version": "3.14"
+            },
+            {
               "ansible-version": "stable-2.18",
               "python-version": "3.10"
             },
@@ -47,5 +55,13 @@ jobs:
             },
             {
               "ansible-version": "stable-2.16"
-            }
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
           ]

--- a/roles/customized_ami/defaults/main.yml
+++ b/roles/customized_ami/defaults/main.yml
@@ -4,7 +4,10 @@ customized_ami_source_ami_filters:
   architecture: x86_64
   virtualization-type: hvm
   root-device-type: ebs
-  name: Fedora-Cloud-Base-39-*
+  # CentOS Community Platform Engineering (CPE)
+  owner-id: "125523088429"
+  # Avoid ELN/Rawhide; match current Fedora 4x cloud images
+  name: Fedora-Cloud-Base-*.x86_64-4*
 customized_ami_source_ami_user_name: fedora
 
 customized_ami_vpc_cidr: 10.1.0.0/16

--- a/roles/customized_ami/tasks/create_ec2_resources.yaml
+++ b/roles/customized_ami/tasks/create_ec2_resources.yaml
@@ -82,7 +82,10 @@
     hostname: ec2
     ansible_ssh_user: "{{ customized_ami_source_ami_user_name }}"
     ansible_host: "{{ customized_ami__ec2.instances.0.public_ip_address }}"
-    ansible_ssh_common_args: -o "UserKnownHostsFile=/dev/null" -o StrictHostKeyChecking=no -i {{ customized_ami_private_key_file }}
+    # Prefer ansible_ssh_private_key_file over -i so ~ expands; IdentitiesOnly
+    # avoids "Too many authentication failures" when ssh-agent has many keys.
+    ansible_ssh_private_key_file: "{{ customized_ami_private_key_file | expanduser }}"
+    ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
     ansible_python_interpreter: auto
 
 - name: Gather facts from ec2 instance

--- a/roles/deploy_flask_app/tasks/setup_infra.yaml
+++ b/roles/deploy_flask_app/tasks/setup_infra.yaml
@@ -23,19 +23,31 @@
     hostname: "{{ deploy_flask_app__bastion_hostname }}"
     ansible_ssh_user: "{{ deploy_flask_app_bastion_host_username }}"
     ansible_host: "{{ deploy_flask_app__bastion_public_ip }}"
-    ansible_python_interpreter: auto
-    ansible_ssh_common_args: '-o "UserKnownHostsFile=/dev/null" -o StrictHostKeyChecking=no -i {{ deploy_flask_app_bastion_ssh_private_key_path }}'
+    ansible_python_interpreter: /usr/bin/python3
+    # Prefer ansible_ssh_private_key_file over -i so ~ expands; IdentitiesOnly
+    # avoids "Too many authentication failures" when ssh-agent has many keys.
+    ansible_ssh_private_key_file: "{{ deploy_flask_app_bastion_ssh_private_key_path | expanduser }}"
+    ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
 
 - name: Create key pair to connect to the workers
   amazon.aws.ec2_key:
     name: "{{ deploy_flask_app__workers_keypair_name }}"
   register: deploy_flask_app__keypair_result
 
+- name: Ensure SSH directory exists on bastion host
+  ansible.builtin.file:
+    path: "{{ deploy_flask_app_workers_ssh_private_key | dirname }}"
+    state: directory
+    mode: "0700"
+  when: (deploy_flask_app_workers_ssh_private_key | dirname) not in ['/tmp', '/var/tmp', '/']
+  delegate_to: "{{ deploy_flask_app__bastion_hostname }}"
+
 - name: Save key pair content into file on bastion host
   ansible.builtin.copy:
     content: "{{ deploy_flask_app__keypair_result.key.private_key }}"
     dest: "{{ deploy_flask_app_workers_ssh_private_key }}"
-    mode: 0600
+    mode: "0600"
+    unsafe_writes: true
   when: deploy_flask_app__keypair_result is changed
   delegate_to: "{{ deploy_flask_app__bastion_hostname }}"
 

--- a/roles/manage_transit_gateway/tasks/create_vpn_attachment.yaml
+++ b/roles/manage_transit_gateway/tasks/create_vpn_attachment.yaml
@@ -13,5 +13,5 @@
 
 - name: Print debug message
   ansible.builtin.debug:
-    msg: Transit gateway VPN attachment {{ item.name }} already exists.
+    msg: Transit gateway VPN attachment for customer gateway {{ item.customer_gateway_id }} already exists.
   when: manage_transit_gateway_tgw_vpn_attachment_result is not changed

--- a/tests/integration/targets/setup_rsa_keys/handlers/main.yml
+++ b/tests/integration/targets/setup_rsa_keys/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Delete temporary RSA key directory
+- name: Delete RSA key directory
   ansible.builtin.file:
     state: absent
-    path: "{{ setup_rsa_keys__tmpdir }}"
+    path: "{{ setup_rsa_keys__path }}"
   ignore_errors: true

--- a/tests/integration/targets/setup_rsa_keys/tasks/main.yml
+++ b/tests/integration/targets/setup_rsa_keys/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
-- name: Create temporary directory to generate keys
-  ansible.builtin.tempfile:
+- name: Create directory to generate keys in
+  ansible.builtin.file:
+    path: "{{ setup_rsa_keys__path }}"
     state: directory
-    suffix: ssh
-  register: setup_rsa_keys__tmpdir
-  notify: 'Delete temporary RSA key directory'
+  notify: 'Delete RSA key directory'
 
 - name: Generate RSA keys
   community.crypto.openssh_keypair:
-    path: "{{ setup_rsa_keys__tmpdir.path }}/id_rsa"
+    path: "{{ setup_rsa_keys__path }}/id_rsa"
+    unsafe_writes: true
 
 - name: Define path to private and public keys
   ansible.builtin.set_fact:
-    setup_rsa_keys__public_key_file: "{{ setup_rsa_keys__tmpdir.path }}/id_rsa.pub"
-    setup_rsa_keys__private_key_file: "{{ setup_rsa_keys__tmpdir.path }}/id_rsa"
+    setup_rsa_keys__public_key_file: "{{ setup_rsa_keys__path }}/id_rsa.pub"
+    setup_rsa_keys__private_key_file: "{{ setup_rsa_keys__path }}/id_rsa"

--- a/tests/integration/targets/test_awsconfig_detach_and_delete_internet_gateway/defaults/main.yml
+++ b/tests/integration/targets/test_awsconfig_detach_and_delete_internet_gateway/defaults/main.yml
@@ -5,7 +5,10 @@ test_image_filter:
   architecture: x86_64
   virtualization-type: hvm
   root-device-type: ebs
-  name: Fedora-Cloud-Base-39-*
+  # CentOS Community Platform Engineering (CPE)
+  owner-id: "125523088429"
+  # Avoid ELN/Rawhide; match current Fedora 4x cloud images
+  name: Fedora-Cloud-Base-*.x86_64-4*
 
 test_vpc_name: "vpc-{{ resource_prefix }}"
 test_vpc_cidr: "172.{{ 255 | random(seed=resource_prefix) }}.0.0/16"

--- a/tests/integration/targets/test_backup_select_resources/defaults/main.yml
+++ b/tests/integration/targets/test_backup_select_resources/defaults/main.yml
@@ -3,8 +3,8 @@ aws_session_token: '{{ security_token | default(omit) }}'
 plan_name: "{{ resource_prefix }}-plan"
 selection_name: "{{ resource_prefix }}-selection"
 selection_two: "{{ resource_prefix }}-selection-2"
-test_iam_role_name: "{{ resource_prefix }}-iam-role"
-test_iam_role_name_new: "{{ resource_prefix }}-iam-role-new"
+test_iam_role_name: "ansible-test-{{ tiny_prefix }}-backup-iam-role"
+test_iam_role_name_new: "ansible-test-{{ tiny_prefix }}-backup-iam-role-new"
 test_vault_name: "{{ resource_prefix }}-vault"
 daily_backup:  # Daily backup at 5am UTC with Amazon defaults for all other settings
   rule_name: daily

--- a/tests/integration/targets/test_customized_ami/tasks/create_infra.yml
+++ b/tests/integration/targets/test_customized_ami/tasks/create_infra.yml
@@ -83,6 +83,10 @@
             - "{{ test__security_group.group_id }}"
         security_groups:
           - "{{ test__security_group.group_id }}"
+        user_data: |
+          #!/bin/bash
+          set -euo pipefail
+          dnf install -y python3-coverage
         wait: true
         state: started
       register: test__ec2_instance
@@ -92,5 +96,8 @@
         hostname: "{{ ami_ec2_instance_name }}"
         ansible_ssh_user: "{{ ami_user_name }}"
         ansible_host: "{{ test__ec2_instance.instances.0.public_ip_address }}"
-        ansible_ssh_common_args: -o "UserKnownHostsFile=/dev/null" -o StrictHostKeyChecking=no -i {{ setup_rsa_keys__private_key_file }}
+        # Prefer ansible_ssh_private_key_file over -i so ~ expands; IdentitiesOnly
+        # avoids "Too many authentication failures" when ssh-agent has many keys.
+        ansible_ssh_private_key_file: "{{ setup_rsa_keys__private_key_file | expanduser }}"
+        ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
         ansible_python_interpreter: auto

--- a/tests/integration/targets/test_customized_ami/tasks/main.yml
+++ b/tests/integration/targets/test_customized_ami/tasks/main.yml
@@ -14,7 +14,7 @@
         name: cloud.aws_ops.customized_ami
       vars:
         customized_ami_packages:
-          - podman
+          - nginx
         customized_ami_name: "{{ custom_ami_name }}"
 
     - name: Validate settings for initial AMI
@@ -24,11 +24,12 @@
         - name: Create EC2 instance using custom AMI
           ansible.builtin.include_tasks: create_infra.yml
 
-        - name: Ensure Podman is installed into EC2 instance
-          ansible.builtin.command: podman pull docker.io/nginx
+        - name: Start nginx service on EC2 instance
+          ansible.builtin.service:
+            name: nginx
+            state: started
           delegate_to: "{{ ami_ec2_instance_name }}"
           become: true
-          changed_when: false
 
     # Test: update custom AMI
     - name: Update custom AMI
@@ -47,15 +48,15 @@
         - name: Create EC2 instance using custom AMI
           ansible.builtin.include_tasks: create_infra.yml
 
-        - name: Trying to run Podman
-          ansible.builtin.command: podman pull docker.io/nginx
+        - name: Check nginx package from initial AMI is not present
+          ansible.builtin.command: rpm -q nginx
           ignore_errors: true
           register: __result
           delegate_to: "{{ ami_ec2_instance_name }}"
           become: true
           changed_when: false
 
-        - name: Validate that Podman is not installed
+        - name: Validate that nginx from initial AMI is not present
           ansible.builtin.assert:
             that:
               - __result is failed

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
@@ -132,7 +132,7 @@
     - name: Set variable for rds_engine_version' variable
       ansible.builtin.set_fact:
         rds_engine_version: "{{ run_deploy_flask_app_rds_engine_version.db_engine_versions.0.engine_version }}"
-    
+
     - name: Create RDS instance (PostGreSQL Database)
       amazon.aws.rds_instance:
         force_update_password: true

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/create.yaml
@@ -7,6 +7,7 @@
           architecture: x86_64
           virtualization-type: hvm
           root-device-type: ebs
+          owner-id: "{{ image_owner_id }}"
           name: "{{ image_filter }}"
       register: images
 
@@ -122,6 +123,16 @@
         state: present
       register: rds_sg
 
+    - name: Gather information about RDS engine version
+      amazon.aws.rds_engine_versions_info:
+        engine: "{{ rds_engine }}"
+        default_only: true
+      register: run_deploy_flask_app_rds_engine_version
+
+    - name: Set variable for rds_engine_version' variable
+      ansible.builtin.set_fact:
+        rds_engine_version: "{{ run_deploy_flask_app_rds_engine_version.db_engine_versions.0.engine_version }}"
+    
     - name: Create RDS instance (PostGreSQL Database)
       amazon.aws.rds_instance:
         force_update_password: true
@@ -152,6 +163,7 @@
     - name: Generate RSA keys
       community.crypto.openssh_keypair:
         path: "{{ deploy_flask_app_bastion_rsa_key_dir }}/id_rsa"
+        unsafe_writes: true
 
     - name: Create key pair to connect to the VM
       amazon.aws.ec2_key:
@@ -184,7 +196,8 @@
           - "{{ secgroup.group_id }}"
         user_data: |
           #!/bin/bash
-          yum install -y python3 python3-virtualenv sshpass netcat ansible-core
+          set -euo pipefail
+          dnf install -y python3 python3-virtualenv sshpass nmap-ncat ansible-core python3-coverage
         wait: true
         state: started
       register: vm_result

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/validate_create.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/tasks/validate_create.yaml
@@ -11,7 +11,7 @@
     deploy_flask_app_bastion_instance_id: "{{ vm_result.instance_ids.0 }}"
     deploy_flask_app_rds_host: "{{ rds_result.endpoint.address }}"
     deploy_flask_app_rds_dbname: "{{ rds_result.db_name }}"
-    deploy_flask_app_bastion_ssh_private_key_path: "{{ deploy_flask_app_bastion_rsa_key_dir }}/id_rsa"
+    deploy_flask_app_bastion_ssh_private_key_path: "{{ deploy_flask_app_bastion_rsa_key_dir | expanduser }}/id_rsa"
 
 - name: Check that a page returns successfully
   ansible.builtin.uri:

--- a/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/vars/main.yaml
+++ b/tests/integration/targets/test_deploy_flask_app/roles/run_deploy_flask_app/vars/main.yaml
@@ -19,11 +19,11 @@ rds_allocated_storage_gb: 20
 rds_instance_class: db.m6g.large
 rds_instance_name: mysampledb123
 rds_engine: postgres
-rds_engine_version: "16.3"
 bastion_host_type: t3.micro
 bastion_host_venv_path: ~/env
-image_filter: Fedora-Cloud-Base-39-*
-bastion_host_iam_role: "{{ resource_prefix }}-role"
+image_filter: Fedora-Cloud-Base-*.x86_64-4*
+image_owner_id: "125523088429"
+bastion_host_iam_role: "ansible-test-{{ tiny_prefix }}-bastion-host-role"
 
 # vars for the deploy_flask_app role and create task
 # =================================================
@@ -46,3 +46,9 @@ deploy_flask_app_force_init: false
 deploy_flask_app_rds_master_password: L#5cH2mgy_
 deploy_flask_app_rds_master_username: ansible
 deploy_flask_app_bastion_rsa_key_dir: "~/.ssh-{{ resource_prefix }}"
+
+# Role defaults use /tmp paths; on Fedora bastions the fedora user cannot
+# chmod /tmp when ensuring the parent directory for the workers SSH key.
+deploy_flask_app_workers_ssh_private_key: ~/.ssh/workers_id_rsa
+deploy_flask_app_workers_inventory_file: ~/workers_inventory.yaml
+deploy_flask_app_workers_playbook_file: ~/deploy_app.yaml

--- a/tests/integration/targets/test_ec2_instance_terminate_by_tag/tasks/setup.yml
+++ b/tests/integration/targets/test_ec2_instance_terminate_by_tag/tasks/setup.yml
@@ -13,7 +13,10 @@
           architecture: x86_64
           virtualization-type: hvm
           root-device-type: ebs
-          name: Fedora-Cloud-Base-39-*
+          # CentOS Community Platform Engineering (CPE)
+          owner-id: "125523088429"
+          # Avoid ELN/Rawhide; match current Fedora 4x cloud images
+          name: Fedora-Cloud-Base-*.x86_64-4*
       register: images
       # very spammy
       no_log: true

--- a/tests/integration/targets/test_move_objects_between_buckets/tasks/main.yml
+++ b/tests/integration/targets/test_move_objects_between_buckets/tasks/main.yml
@@ -31,7 +31,7 @@
     - name: Put object (text) in source bucket
       amazon.aws.s3_object:
         bucket: "{{ bucket.src }}"
-        object: /template/test.txt
+        object: template/test.txt
         content: "{{ lookup('file', 'test.txt') }}"
         mode: put
 


### PR DESCRIPTION
Resolves
[ACA-6690](https://redhat.atlassian.net/browse/ACA-6690)

SUMMARY
Updates Python version to 3.13 in integration and coverage test workflows.

Changes:

Set PYTHON_VERSION to 3.13 in coverage_test.yml
Set PYTHON_VERSION to 3.13 in integration.yml
Install community.general tests dependancy.
The AMI lookup for Fedora-Cloud-Base-39-* returned no images — those Fedora 39 AMIs are no longer available in AWS. Updated AMI filters Owner: 125523088429 (CentOS Community Platform Engineering)
Name: Fedora-Cloud-Base-.x86_64-4 (matches current Fedora 4x images, excludes ELN/Rawhide)
Update coverage_test to run only on push, instead of each pull_request.
Fix integration test test_backup_select_resources - update iam create role to include ansible-test prefix.
Fix integration test test_deploy_flask_app - Gather information about RDS engine version instead of using a constant var value.
Fix integration test test_deploy_flask_app - update bastion_host_iam_role iam create role to include ansible-test prefix.
Fix integration test test_move_objects_between_buckets - The failure comes from stricter validation in amazon.aws.s3_object: object keys must not start with /, the integration test was putting an object at /template/test.txt, but the rest of the test already expects template/test.txt (no leading slash)
Fix integration test test_customized_ami - use setup_rsa_keys__path with ansible.builtin.file instead of tempfile.
Update roles/deploy_flask_app - Move key path from /tmp/id_rsa → ~/.ssh/workers_id_rsa
Fix integration test test_deploy_flask_app - Fixing bastion user_data in test_deploy_flask_app to use dnf and Fedora-appropriate packages.
Update roles test_customized_ami and test_customized_ami - to install coverage on the bastion host for coverage collection.
Updated test_customized_ami to use a package we control, ngnix, instead of relying on podman being absent from the Fedora 4x base image.
Updated Sanity workflow - I added the missing { so the entry is valid JSON again. The matrix_exclude array now parses with all 13 entries.

Updated roles/manage_transit_gateway - updated debug message.
ISSUE TYPE
Test Pull Request

COMPONENT NAME
CI/CD workflows

Reported CI Issues
Integration tests https://github.com/redhat-cop/cloud.aws_ops/issues/184

Assisted-by: Claude Sonnet 4.5 (claude-sonnet-4-5@20250929)

(cherry picked from commit https://github.com/redhat-cop/cloud.aws_ops/commit/e8f35dcd75f29b81f7487e88725252e63d716d77)